### PR TITLE
max_in_flight=1 issues

### DIFF
--- a/nsq/nsq.py
+++ b/nsq/nsq.py
@@ -81,7 +81,7 @@ def identify(data):
 
 def ready(count):
     assert isinstance(count, int), "ready count must be an integer"
-    assert count > 0, "ready count cannot be negative"
+    assert count >= 0, "ready count cannot be negative"
     return _command('RDY', None, str(count))
 
 def finish(id):


### PR DESCRIPTION
we noticed in one of our systems that when a consumer is configured with `max_in_flight=1` and they connect to more than one producer for a topic that you effectively get `max_in_flight=<num_producers>`.

the impact this can have is that messages are pushed to the consumer in situations where it is unable to actually  process and respond to that message.  this leads to timeouts and requeues.

on the client side, this can be resolved by providing different behavior to handle the case where `max_in_flight < num_producers`, like round-robin.

this would also need to handle the case where all consumers could become pegged to a single host that (for whatever reason) isn't actively producing messages by accounting for that and sending `RDY` state to another producer.

cc @jehiah
