### PR TITLE
force tornado 2.4.1 in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,14 @@ python:
   - "2.5"
   - "2.6"
   - "2.7"
+env:
+  - TORNADO_VERSION=1.2.1
+  - TORNADO_VERSION=2.4.1
+  - TORNADO_VERSION=3.0
 install:
   - "pip install simplejson --use-mirrors"
-  - "pip install tornado --use-mirrors"
-script: py.test
+  - "pip install pycurl --use-mirrors"
+  - "pip install tornado==$TORNADO_VERSION --use-mirrors"
+script: ./test.sh
 notifications:
   email: false

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PYTHON_VERSION" == "2.5" ] && [ "$TORNADO_VERSION" == "3.0" ]; then
+    echo "skipping tests for python 2.5 and tornado 3.0 (incompatible)"
+    exit 0
+fi
+
+py.test
+exit $?


### PR DESCRIPTION
tornado 3.0 was released and drops python 2.5 compatibility (yay) cc @jehiah
