### PR TITLE
export Message and minor fix

### DIFF
--- a/nsq/Reader.py
+++ b/nsq/Reader.py
@@ -375,6 +375,9 @@ class Reader(object):
             logging.exception('[%s] failed to bootstrap connection' % conn.id)
     
     def _identify_response_callback(self, conn, data):
+        if data == 'OK':
+            return
+        
         try:
             data = json.loads(data)
         except json.JSONDecodeError:

--- a/nsq/__init__.py
+++ b/nsq/__init__.py
@@ -2,8 +2,8 @@ import signal
 import tornado.ioloop
 import logging
 
-from nsq import unpack_response, decode_message, identify, subscribe, ready, finish, touch, requeue, nop
-from nsq import valid_topic_name, valid_channel_name
+from nsq import Message, unpack_response, decode_message, valid_topic_name, valid_channel_name
+from nsq import identify, subscribe, ready, finish, touch, requeue, nop
 from nsq import FRAME_TYPE_RESPONSE, FRAME_TYPE_ERROR, FRAME_TYPE_MESSAGE, TOUCH, FIN, REQ
 from BackoffTimer import BackoffTimer
 from sync import SyncConn
@@ -20,10 +20,10 @@ def run():
     tornado.ioloop.IOLoop.instance().start()
 
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 __author__ = "Matt Reiferson <snakes@gmail.com>"
-__all__ = ["Reader", "run", "BackoffTimer",
+__all__ = ["Reader", "run", "BackoffTimer", "Message",
            "SyncConn", "AsyncConn", "unpack_response", "decode_message",
            "identify", "subscribe", "ready", "finish", "touch", "requeue", "nop",
            "valid_topic_name", "valid_channel_name",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '0.4.0'
+version = '0.4.1'
 
 setup(name='pynsq',
       version=version,


### PR DESCRIPTION
this exports Message in the top level and fixes a case where a new pynsq client connected to an old nsqd and printed a misleading error message cc @jehiah @danielhfrank
