### PR TITLE
improve RDY handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ env:
   - TORNADO_VERSION=1.2.1
   - TORNADO_VERSION=2.4.1
   - TORNADO_VERSION=3.0.2
+matrix:
+  exclude:
+    - python: "2.5"
+      env: TORNADO_VERSION=3.0.2
 install:
   - "pip install simplejson --use-mirrors"
   - "pip install pycurl --use-mirrors"
   - "pip install tornado==$TORNADO_VERSION --use-mirrors"
-script: ./test.sh
+script: py.test
 notifications:
   email: false

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,22 @@
 # Changelog
 
-## 0.4.3-alpha 
+## 0.5.0-alpha
 
- * #13 - improve backoff handling
+This release drops the concept of "tasks" in `Reader` (in favor of a single message handler). This
+greatly simplifies internal RDY state handling and is a cleaner API as we head towards 1.0.
+
+These changes modify the public API and break backwards compatibility. To ease the transition we've
+added a `LegacyReader` class that accepts the previous version's arguments and facilitates
+instantiating new `Reader` instances for each task with the same automatic channel naming
+conventions.
+
+We suggest you begin to migrate towards using the new API directly (`LegacyReader` will not be
+in the 1.0 release), but for now the upgrade is as simple as:
+
+    from nsq import LegacyReader as Reader
+
+ * #29 - refactor public API (drop "tasks"); improve RDY count handling
+ * #28/#31 - improve backoff handling
 
 ## 0.4.2 - 2013-05-09
 
@@ -16,12 +30,11 @@
 ## 0.4.0 - 2013-04-19
 
  * #22 - feature negotiation (supported by nsqd v0.2.20+)
-        wait 2x heartbeat interval before closing conns
-        more logging improvements
+         wait 2x heartbeat interval before closing conns
+         more logging improvements
  * #21 - configurable heartbeat interval (supported by nsqd v0.2.19+)
  * #17 - add task to all connection related logging; ensure max_in_flight is never < # tasks
  * #16 - always set initial RDY count to 1
- * #15 - run travis tests on more tornado versions
  * #14 - automatically reconnect to nsqd when not using lookupd
  * #12 - cleanup/remove deprecated async=True
  * #9 - redistribute ready state when max_in_flight < num_conns

--- a/nsq/LegacyReader.py
+++ b/nsq/LegacyReader.py
@@ -1,0 +1,52 @@
+import warnings
+from Reader import Reader
+
+
+class LegacyReader(object):
+    """
+    In v0.5.0 we dropped support for "tasks" in the Reader API in favor of a single message handler.
+    
+    LegacyReader is a backwards compatible API for clients interacting with v0.5.0+ that
+    want to continue to use "tasks".
+    
+    Usage:
+    
+    from nsq import LegacyReader as Reader
+    """
+    def __init__(self, *args, **kwargs):
+        warnings.warn("LegacyReader is a deprecated wrapper and will be removed in a future release.  Use (multiple) Reader(s) each with their own message handler.", DeprecationWarning)
+        
+        old_params = {}
+        
+        old_kwargs = ('all_tasks', 'topic', 'channel' 
+            'nsqd_tcp_addresses', 'lookupd_http_addresses'
+            'max_tries', 'max_in_flight', 'requeue_delay', 'lookupd_poll_interval',
+            'low_rdy_idle_timeout', 'heartbeat_interval', 'max_backoff_duration')
+        
+        if args:
+            keys = old_kwargs[:len(args)]
+            old_params = dict(zip(keys, args))
+        
+        old_params.update(kwargs)
+        
+        all_tasks = old_params['all_tasks']
+        topic = old_params['topic']
+        channel = old_params['channel']
+        
+        del old_params['all_tasks']
+        del old_params['topic']
+        del old_params['channel']
+        
+        assert isinstance(all_tasks, dict)
+        for key, method in all_tasks.items():
+            assert callable(method), "key %s must have a callable value" % key
+        
+        self.readers = []
+        for task, method in all_tasks.items():
+            if len(all_tasks) > 1:
+                task_channel = channel + '.' + task
+            else:
+                task_channel = channel
+            
+            r = Reader(topic=topic, channel=task_channel, message_handler=method, **old_params)
+            self.readers.append(r)

--- a/nsq/__init__.py
+++ b/nsq/__init__.py
@@ -9,6 +9,7 @@ from BackoffTimer import BackoffTimer
 from sync import SyncConn
 from async import AsyncConn
 from Reader import Reader
+from LegacyReader import LegacyReader
 from Writer import Writer
 
 
@@ -24,7 +25,7 @@ def run():
 __version__ = '0.4.3-alpha'
 
 __author__ = "Matt Reiferson <snakes@gmail.com>"
-__all__ = ["Reader", "Writer", "run", "BackoffTimer", "Message", "Error",
+__all__ = ["Reader", "Writer", "run", "BackoffTimer", "Message", "Error", "LegacyReader"
            "SyncConn", "AsyncConn", "unpack_response", "decode_message",
            "identify", "subscribe", "ready", "finish", "touch", "requeue", "nop","pub", "mpub",
            "valid_topic_name", "valid_channel_name",

--- a/test.sh
+++ b/test.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [ "$TRAVIS_PYTHON_VERSION" == "2.5" ] && [[ "$TORNADO_VERSION" =~ "3.0" ]]; then
-    echo "skipping tests for python 2.5 and tornado 3.0 (incompatible)"
-    exit 0
-fi
-
-py.test
-exit $?

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -17,104 +17,132 @@ def two_arg_fxn(arg1, arg2):
 
 def _get_test_conn():
     conn = Mock()
-    conn.task = "test"
-    conn.in_flight = 50
-    conn.ready = 25
-    conn.max_rdy_count = 50
+    conn.rdy = 0
+    conn.last_rdy = 0
+    conn.in_flight = 0
+    conn.max_rdy_count = 2500
     return conn
 
 def _get_test_message():
-    msg = nsq.Message("1234", "{}", 1234, 0)
-    return msg
+    return nsq.Message("1234", "{}", 1234, 0)
 
 @patch('nsq.async.tornado.iostream.IOStream', autospec=True)
 @patch('nsq.async.tornado.ioloop.IOLoop', autospec=True)
 def test_backoff_easy(mock_ioloop, mock_iostream):
     conn = _get_test_conn()
     msg = _get_test_message()
-
+    
     instance = Mock()
     mock_ioloop.instance.return_value = instance
-
-    r = nsq.Reader({"test" : two_arg_fxn}, "test", "test", nsqd_tcp_addresses = ["test:9999",], max_in_flight = 5)
-    r.conns["test:9999:test"] = conn
-    r.total_ready = 0
-
-    r._client_callback(nsq.REQ, task="test", conn=conn, message=msg)
-
-    assert r.backoff_block["test"] == True
-    assert r.backoff_timer["test"].get_interval() > 0
+    
+    r = nsq.Reader("test", "test", message_handler=two_arg_fxn, nsqd_tcp_addresses=["test:9999"], max_in_flight=5)
+    r.conns["test:9999"] = conn
+    r._send_rdy(conn, 5)
+    
+    conn.in_flight += 1
+    conn.rdy -= 1
+    r.total_rdy -= 1
+    
+    r._message_responder(nsq.REQ, conn=conn, message=msg)
+    assert r.backoff_block == True
+    assert r.backoff_timer.get_interval() > 0
     assert instance.add_timeout.called
-
-    send_args, send_kwargs = conn.send.call_args
-    assert send_args[0] == 'RDY 0\n'
-
+    
     timeout_args, timeout_kwargs = instance.add_timeout.call_args
     timeout_args[1]()
-    assert r.backoff_block["test"] == False
+    assert r.backoff_block == False
     send_args, send_kwargs = conn.send.call_args
     assert send_args[0] == 'RDY 1\n'
-
-    r._client_callback(nsq.FIN, task="test", conn=conn, message=msg)
-    assert r.backoff_block["test"] == False
-    assert r.backoff_timer["test"].get_interval() == 0
-
-    send_args, send_kwargs = conn.send.call_args
-    assert send_args[0] == 'RDY 5\n'
+    
+    conn.in_flight += 1
+    conn.rdy -= 1
+    r.total_rdy -= 1
+    
+    r._message_responder(nsq.FIN, conn=conn, message=msg)
+    assert r.backoff_block == False
+    assert r.backoff_timer.get_interval() == 0
+    
+    expected_args = ['RDY 5\n', 'REQ 1234 0\n',
+        'RDY 0\n', 'RDY 1\n',
+        'FIN 1234\n', 'RDY 5\n']
+    assert conn.send.call_args_list == [((arg,),) for arg in expected_args]
 
 @patch('nsq.async.tornado.iostream.IOStream', autospec=True)
 @patch('nsq.async.tornado.ioloop.IOLoop', autospec=True)
 def test_backoff_hard(mock_ioloop, mock_iostream):
     conn = _get_test_conn()
     msg = _get_test_message()
-
+    
+    expected_args = []
+    
     instance = Mock()
     mock_ioloop.instance.return_value = instance
-
-    r = nsq.Reader({"test" : two_arg_fxn}, "test", "test", nsqd_tcp_addresses = ["test:9999",], max_in_flight = 5)
-    r.conns["test:9999:test"] = conn
-    r.total_ready = 0
-
+    
+    r = nsq.Reader("test", "test", message_handler=two_arg_fxn, nsqd_tcp_addresses=["test:9999"], max_in_flight=5)
+    r.conns["test:9999"] = conn
+    r._send_rdy(conn, 5)
+    expected_args.append('RDY 5\n')
+    
     num_fails = 0
     fail = True
     last_timeout_time = 0
     for i in range(50):
+        conn.in_flight += 1
+        conn.rdy -= 1
+        r.total_rdy -= 1
+        
         if fail:
-            r._client_callback(nsq.REQ, task="test", conn=conn, message=msg)
+            print 'REQ'
+            r._message_responder(nsq.REQ, conn=conn, message=msg)
             num_fails += 1
-
-            send_args, send_kwargs = conn.send.call_args
-            assert send_args[0] == 'RDY 0\n'
+            
+            expected_args.append('REQ 1234 0\n')
+            if num_fails == 1:
+                expected_args.append('RDY 0\n')
         else:
-            r._client_callback(nsq.FIN, task="test", conn=conn, message=msg)
+            print 'FIN'
+            r._message_responder(nsq.FIN, conn=conn, message=msg)
             num_fails -= 1
-
-        assert r.backoff_block["test"] == True
-        assert r.backoff_timer["test"].get_interval() > 0
+            
+            expected_args.append('FIN 1234\n')
+        
+        assert r.backoff_block == True
+        assert r.backoff_timer.get_interval() > 0
         assert instance.add_timeout.called
-
+        
         timeout_args, timeout_kwargs = instance.add_timeout.call_args
         if timeout_args[0] != last_timeout_time:
             timeout_args[1]()
             last_timeout_time = timeout_args[0]
-        assert r.backoff_block["test"] == False
-        send_args, send_kwargs = conn.send.call_args
-        assert send_args[0] == 'RDY 1\n'
-
+        assert r.backoff_block == False
+        expected_args.append('RDY 1\n')
+        
         fail = True
-        if random.random() < 0.1 and num_fails > 1:
+        if random.random() < 0.3 and num_fails > 1:
             fail = False
-
-    for i in range(num_fails+1):
-        r._client_callback(nsq.FIN, task="test", conn=conn, message=msg)
+    
+    for i in range(num_fails - 1):
+        conn.in_flight += 1
+        conn.rdy -= 1
+        r.total_rdy -= 1
+        
+        r._message_responder(nsq.FIN, conn=conn, message=msg)
+        expected_args.append('FIN 1234\n')
         timeout_args, timeout_kwargs = instance.add_timeout.call_args
         if timeout_args[0] != last_timeout_time:
             timeout_args[1]()
             last_timeout_time = timeout_args[0]
-
-    r._client_callback(nsq.FIN, task="test", conn=conn, message=msg)
-    assert r.backoff_block["test"] == False
-    assert r.backoff_timer["test"].get_interval() == 0
-
-    send_args, send_kwargs = conn.send.call_args_list[-3]
-    assert send_args[0] == 'RDY 5\n'
+        expected_args.append('RDY 1\n')
+    
+    conn.in_flight += 1
+    conn.rdy -= 1
+    r.total_rdy -= 1
+    
+    r._message_responder(nsq.FIN, conn=conn, message=msg)
+    expected_args.append('FIN 1234\n')
+    expected_args.append('RDY 5\n')
+    
+    assert r.backoff_block == False
+    assert r.backoff_timer.get_interval() == 0
+    
+    assert conn.send.call_args_list == [((arg,),) for arg in expected_args]


### PR DESCRIPTION
this is a change pulled out of #28 

The code managing that over-subscribed state with self.total_ready is deficient in two ways. 

 1) It doesn't account for multiple tasks (we've implemented in_flight_count as per-task), and
 2) it is never incremented (oops!) when RDY is updated, so it can't be checked against for calculation. It appears that it only works at initial connection time now.
