### PR TITLE
fix incomplete clearing of RDY timeout reference

### DIFF
--- a/nsq/Reader.py
+++ b/nsq/Reader.py
@@ -340,7 +340,7 @@ class Reader(object):
             self._send_rdy(c, 0)
             if c.rdy_timeout:
                 self.ioloop.remove_timeout(c.rdy_timeout)
-                conn.rdy_timeout = None
+                c.rdy_timeout = None
         
         send_rdy_callback = functools.partial(self._send_rdy, conn, 1)
         finish_backoff_callback = functools.partial(self._finish_backoff, send_rdy_callback)


### PR DESCRIPTION
fixes:

```
[I 130624 16:03:34 Reader:578] [host:4150:topic:channel] redistributing RDY
[E 130624 16:03:34 ioloop:419] Error in periodic callback
    Traceback (most recent call last):
      File "/usr/local/lib/python2.5/site-packages/tornado/ioloop.py", line 415, in _run
        self.callback()
      File "/usr/local/lib/python2.5/site-packages/nsq/Reader.py", line 579, in _redistribute_rdy_state
        self._send_rdy(conn, 1)
      File "/usr/local/lib/python2.5/site-packages/nsq/Reader.py", line 361, in _send_rdy
        self.ioloop.remove_timeout(conn.rdy_timeout)
      File "/usr/local/lib/python2.5/site-packages/tornado/ioloop.py", line 322, in remove_timeout
        self._timeouts.remove(timeout)
    ValueError: list.remove(x): x not in list
```

cc @jehiah
