### PR TITLE
Fix Writer Error Caused by Setting id Property of AsyncConn

### DIFF
--- a/nsq/Writer.py
+++ b/nsq/Writer.py
@@ -162,7 +162,6 @@ class Writer(object):
                                self._data_callback, self._close_callback)
         conn.connect()
         
-        conn.id = conn_id
         conn.last_recv_timestamp = time.time()
         conn.callback_queue = []
         


### PR DESCRIPTION
There is no setter for this property, so this line was throwing `AttributeError: can't set attribute`. `conn.id` is already what the Writer was setting it to. 
