### PR TITLE
Fix uncaught exception when there are no connections to write to

### DIFF
--- a/nsq/Writer.py
+++ b/nsq/Writer.py
@@ -113,6 +113,10 @@ class Writer(object):
             callback = functools.partial(self._finish_pub, command=command,
                                          topic=topic, msg=msg)
         
+        if not self.conns:
+            callback(None, SendError("No connections"))
+            return
+
         conn = random.choice(self.conns.values())
         try:
             cmd = getattr(nsq, command)


### PR DESCRIPTION
More small Writer changes.

`random.choice()` throws an error with empty lists, and this was not caught, preventing your callback from being called when there are no connections. 
