### PR TITLE
writer: unicode command parameters

### DIFF
--- a/nsq/nsq.py
+++ b/nsq/nsq.py
@@ -116,8 +116,10 @@ def _command(cmd, body, *params):
     body_data = ''
     params_data = ''
     if body:
+        assert isinstance(body, str), "body must be a string"
         body_data = struct.pack('>l', len(body)) + body
     if len(params):
+        params = [p.encode('utf-8') if isinstance(p, unicode) else p for p in params]
         params_data = ' ' + ' '.join(params)
     return "%s%s%s%s" % (cmd, params_data, NL, body_data)
 


### PR DESCRIPTION
The line `return "%s%s%s%s" % (cmd, params_data, NL, body_data)` concatenates four strings, some of which can be unicode strings. Python then tries to convert the other strings into unicode, potentially throwing things like this (if you have no LANG telling it to use utf8 in your env):

```
    Traceback (most recent call last):
      File "/bitly/local/lib/python2.5/site-packages/nsq/Writer.py", line 123, in _pub
        conn.send(cmd(topic, msg))
      File "/bitly/local/lib/python2.5/site-packages/nsq/nsq.py", line 151, in pub
        return _command('PUB', data, topic)
      File "/bitly/local/lib/python2.5/site-packages/nsq/nsq.py", line 122, in _command
        return "%s%s%s%s" % (cmd, params_data, NL, body_data)
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xb7 in position 3: ordinal not in range(128)
```

This makes sure that everything is utf8. 
