### PR TITLE
reader: fixed never exit the backoff state

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -314,10 +314,14 @@ class Reader(Client):
             return conn
 
     def _on_backoff_resume(self, success, **kwargs):
+        # do nothing
+        if self.backoff_block:
+            return
+
         start_backoff_interval = self.backoff_timer.get_interval()
         if success:
             self.backoff_timer.success()
-        elif not self.backoff_block:
+        else:
             self.backoff_timer.failure()
         self._enter_continue_or_exit_backoff(start_backoff_interval)
 
@@ -329,10 +333,6 @@ class Reader(Client):
         # reach no backoff in which case we go back to the normal RDY count.
 
         current_backoff_interval = self.backoff_timer.get_interval()
-
-        # do nothing
-        if self.backoff_block:
-            return
 
         # we're out of backoff completely, return to full blast for all conns
         if start_backoff_interval and not current_backoff_interval:


### PR DESCRIPTION
reproduction:

step - 1. trigger backoff
step - 2. `Reader._start_backoff_block` is called
step - 3. `self.backoff_block` is set `True`
step - 4. trigger resume
step - 5. backoff timeout and `Reader._finish_backoff_block` is called
step - 6. trigger resume

In step-4: 
`start_backoff_interval` > 0 and `current_backoff_interval` = 0,  
owing to `self.backoff_block` is True, it left the backoff state behind

In step-6:
`start_backoff_interval` = 0 and `current_backoff_interval` = 0, will not exit the backoff state
