### PR TITLE
reader: fix IndexError in Reader._handle_message func

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -260,13 +260,12 @@ class Reader(Client):
         self.total_rdy = max(self.total_rdy - 1, 0)
 
         rdy_conn = conn
-        if len(self.conns) > self.max_in_flight:
+        if len(self.conns) > self.max_in_flight and time.time() - self.random_rdy_ts > 30:
             # if all connections aren't getting RDY
             # occsionally randomize which connection gets RDY
-            time_since_random_rdy = time.time() - self.random_rdy_ts
-            if time_since_random_rdy > 30:
-                self.random_rdy_ts = time.time()
-                conns_with_no_rdy = [c for c in self.conns.itervalues() if not c.rdy]
+            self.random_rdy_ts = time.time()
+            conns_with_no_rdy = [c for c in self.conns.itervalues() if not c.rdy]
+            if conns_with_no_rdy:
                 rdy_conn = random.choice(conns_with_no_rdy)
                 if rdy_conn is not conn:
                     logging.info('[%s:%s] redistributing RDY to %s',


### PR DESCRIPTION
exception:

``` py
Traceback (most recent call last):
  File "/******/site-packages/nsq/reader.py", line 253, in _on_message
    self._handle_message(conn, message)
  File "/******/site-packages/nsq/reader.py", line 268, in _handle_message
    rdy_conn = random.choice(conns_with_no_rdy)
  File "/usr/lib/python2.7/random.py", line 274, in choice
    return seq[int(self.random() * len(seq))]  # raises IndexError if seq is empty
IndexError: list index out of range
```

for more information: max_in_flight=5, nsqd#=20
