### PR TITLE
Add deflate support to AsyncConn

### DIFF
--- a/nsq/deflate_socket.py
+++ b/nsq/deflate_socket.py
@@ -1,0 +1,41 @@
+import zlib
+import socket
+import errno
+
+
+class DeflateSocket(object):
+    def __init__(self, socket, level):
+        wbits = -zlib.MAX_WBITS
+        self._decompressor = zlib.decompressobj(wbits)
+        self._compressor = zlib.compressobj(level, zlib.DEFLATED, wbits)
+        self._bootstrapped = None
+        self._socket = socket
+
+    def __getattr__(self, name):
+        return getattr(self._socket, name)
+
+    def bootstrap(self, data):
+        if data:
+            self._bootstrapped = self._decompressor.decompress(data)
+
+    def recv(self, size):
+        return self._recv(size, self._socket.recv)
+
+    def read(self, size):
+        return self._recv(size, self._socket.read)
+
+    def _recv(self, size, method):
+        if self._bootstrapped:
+            data = self._bootstrapped
+            self._bootstrapped = None
+            return data
+        chunk = method(size)
+        if chunk:
+            uncompressed = self._decompressor.decompress(chunk)
+        if not uncompressed:
+            raise socket.error(errno.EWOULDBLOCK)
+        return uncompressed
+
+    def send(self, data):
+        chunk = self._compressor.compress(data)
+        self._socket.send(chunk + self._compressor.flush(zlib.Z_SYNC_FLUSH))

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -27,12 +27,14 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         'output_buffer_timeout': 50
     }
 
+    nsqd_command = ['nsqd', '--verbose', '--snappy',
+                    '--tls-key=%s/tests/key.pem' % base_dir,
+                    '--tls-cert=%s/tests/cert.pem' % base_dir]
+
     def setUp(self):
         super(ReaderIntegrationTest, self).setUp()
         self.processes = []
-        proc = subprocess.Popen(['nsqd', '--verbose', '--snappy',
-                                 '--tls-key=%s/tests/key.pem' % base_dir,
-                                 '--tls-cert=%s/tests/cert.pem' % base_dir])
+        proc = subprocess.Popen(self.nsqd_command)
         self.processes.append(proc)
         http = tornado.httpclient.HTTPClient()
         start = time.time()
@@ -74,6 +76,15 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         assert isinstance(response['data'], dict)
         assert response['data']['snappy'] is True
         assert response['data']['tls_v1'] is True
+
+    def test_conn_socket_upgrade(self):
+        c = nsq.async.AsyncConn('127.0.0.1', 4150, io_loop=self.io_loop,
+                                **self.identify_options)
+        c.on('ready', self.stop)
+        c.connect()
+        self.wait()
+        assert isinstance(c.socket, nsq.snappy_socket.SnappySocket)
+        assert isinstance(c.socket._socket, ssl.SSLSocket)
 
     def test_conn_subscribe(self):
         topic = 'test_conn_suscribe_%s' % time.time()
@@ -164,3 +175,42 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
                         io_loop=self.io_loop, message_handler=handler, max_in_flight=100,
                         heartbeat_interval=1)
         self.wait()
+
+
+class DeflateReaderIntegrationTest(ReaderIntegrationTest):
+
+    identify_options = {
+        'user_agent': 'sup',
+        'deflate': True,
+        'deflate_level': 6,
+        'tls_v1': True,
+        'tls_options': {'cert_reqs': ssl.CERT_NONE},
+        'heartbeat_interval': 10,
+        'output_buffer_size': 4096,
+        'output_buffer_timeout': 50
+    }
+
+    nsqd_command = ['nsqd', '--verbose', '--deflate',
+                    '--tls-key=%s/tests/key.pem' % base_dir,
+                    '--tls-cert=%s/tests/cert.pem' % base_dir]
+
+    def test_conn_identify_options(self):
+        c = nsq.async.AsyncConn('127.0.0.1', 4150, io_loop=self.io_loop,
+                                **self.identify_options)
+        c.on('identify_response', self.stop)
+        c.connect()
+        response = self.wait()
+        print response
+        assert response['conn'] is c
+        assert isinstance(response['data'], dict)
+        assert response['data']['deflate'] is True
+        assert response['data']['tls_v1'] is True
+
+    def test_conn_socket_upgrade(self):
+        c = nsq.async.AsyncConn('127.0.0.1', 4150, io_loop=self.io_loop,
+                                **self.identify_options)
+        c.on('ready', self.stop)
+        c.connect()
+        self.wait()
+        assert isinstance(c.socket, nsq.deflate_socket.DeflateSocket)
+        assert isinstance(c.socket._socket, ssl.SSLSocket)


### PR DESCRIPTION
Add support for AsyncConn to send deflate options in identify and wrap the socket with deflate compression. Also duplicated the battery of integration test but with tls+deflate stack instead of tls+snappy.
