### PR TITLE
support lookupd_http_addresses without scheme or path again

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -518,6 +518,10 @@ class Reader(Client):
         endpoint = self.lookupd_http_addresses[self.lookupd_query_index]
         self.lookupd_query_index = (self.lookupd_query_index + 1) % len(self.lookupd_http_addresses)
 
+        # urlsplit() is faulty if scheme not present
+        if '://' not in endpoint:
+            endpoint = 'http://' + endpoint
+
         scheme, netloc, path, query, fragment = urlparse.urlsplit(endpoint)
 
         if not path or path == "/":


### PR DESCRIPTION
A recent commit introduced the use of urlsplit() for parsing
lookupd_http_addresses, and causes endpoints of the form
host:port to no longer work. If the scheme is added to these
endpoint strings which lack them, it works again.

cc @mreiferson @jehiah
