### PR TITLE
Verify Reader kwargs

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -18,6 +18,7 @@ from backoff_timer import BackoffTimer
 from client import Client
 import nsq
 import async
+import inspect
 
 
 class Reader(Client):
@@ -171,6 +172,12 @@ class Reader(Client):
         self.lookupd_poll_interval = lookupd_poll_interval
         self.lookupd_poll_jitter = lookupd_poll_jitter
         self.random_rdy_ts = time.time()
+
+        # Verify keyword arguments
+        valid_args = inspect.getargspec(async.AsyncConn.__init__).args
+        diff = set(kwargs) - set(valid_args)
+        assert len(diff) == 0, 'Invalid keyword argument(s): %s' % list(diff)
+
         self.conn_kwargs = kwargs
 
         self.backoff_timer = BackoffTimer(0, max_backoff_duration)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -54,6 +54,20 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
             os.kill(proc.pid, signal.SIGKILL)
             proc.wait()
 
+    def test_bad_reader_arguments(self):
+        topic = 'test_reader_msgs_%s' % time.time()
+        bad_options = dict(self.identify_options)
+        bad_options.update(dict(foo=10))
+        handler = lambda x: None
+
+        self.assertRaises(
+            AssertionError,
+            nsq.Reader,
+            nsqd_tcp_addresses=['127.0.0.1:4150'], topic=topic,
+            channel='ch', io_loop=self.io_loop,
+            message_handler=handler, max_in_flight=100,
+            **bad_options)
+
     def test_conn_identify(self):
         c = nsq.async.AsyncConn('127.0.0.1', 4150, io_loop=self.io_loop)
         c.on('identify_response', self.stop)


### PR DESCRIPTION
Check keyword arguments passed to Reader constructor. Throw an AssertionError if an invalid argument is passed.

Before this change, specifying an invalid keyword argument would cause the AsyncConn to fail quietly in the Tornado default exception handler during run-time.
