### PR TITLE
Check keyword arguments passed to Reader constructor. Throw an Assertion...

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -18,6 +18,7 @@ from backoff_timer import BackoffTimer
 from client import Client
 import nsq
 import async
+import inspect
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +186,12 @@ class Reader(Client):
         self.lookupd_connect_timeout = lookupd_connect_timeout
         self.lookupd_request_timeout = lookupd_request_timeout
         self.random_rdy_ts = time.time()
+
+        # Verify keyword arguments
+        valid_args = inspect.getargspec(async.AsyncConn.__init__).args
+        diff = set(kwargs) - set(valid_args)
+        assert len(diff) == 0, 'Invalid keyword argument(s): %s' % list(diff)
+
         self.conn_kwargs = kwargs
 
         self.backoff_timer = BackoffTimer(0, max_backoff_duration)

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -7,6 +7,7 @@ import random
 from client import Client
 import nsq
 import async
+import inspect
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,12 @@ class Writer(Client):
         self.name = name or nsqd_tcp_addresses[0]
         self.nsqd_tcp_addresses = nsqd_tcp_addresses
         self.conns = {}
+
+        # Verify keyword arguments
+        valid_args = inspect.getargspec(async.AsyncConn.__init__).args
+        diff = set(kwargs) - set(valid_args)
+        assert len(diff) == 0, 'Invalid keyword argument(s): %s' % list(diff)
+
         self.conn_kwargs = kwargs
         assert isinstance(reconnect_interval, (int, float))
         self.reconnect_interval = reconnect_interval
@@ -132,7 +139,7 @@ class Writer(Client):
         while conn.callback_queue:
             callback = conn.callback_queue.pop(0)
             callback(conn, error)
-    
+
     def _on_connection_response(self, conn, data=None, **kwargs):
         if conn.callback_queue:
             callback = conn.callback_queue.pop(0)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -56,6 +56,20 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
             os.kill(proc.pid, signal.SIGKILL)
             proc.wait()
 
+    def test_bad_reader_arguments(self):
+        topic = 'test_reader_msgs_%s' % time.time()
+        bad_options = dict(self.identify_options)
+        bad_options.update(dict(foo=10))
+        handler = lambda x: None
+
+        self.assertRaises(
+            AssertionError,
+            nsq.Reader,
+            nsqd_tcp_addresses=['127.0.0.1:4150'], topic=topic,
+            channel='ch', io_loop=self.io_loop,
+            message_handler=handler, max_in_flight=100,
+            **bad_options)
+
     def test_conn_identify(self):
         c = nsq.async.AsyncConn('127.0.0.1', 4150, io_loop=self.io_loop)
         c.on('identify_response', self.stop)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,28 @@
+import nsq
+import unittest
+
+
+class WriterUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        super(WriterUnitTest, self).setUp()
+
+    def test_constructor(self):
+        name = 'test'
+        reconnect_interval = 10.0
+        writer = nsq.Writer(nsqd_tcp_addresses=['127.0.0.1:4150'],
+                            reconnect_interval=reconnect_interval,
+                            name=name)
+        self.assertEqual(writer.name, name)
+        self.assertEqual(0, len(writer.conn_kwargs))
+        self.assertEqual(writer.reconnect_interval, reconnect_interval)
+
+    def test_bad_writer_arguments(self):
+        bad_options = dict(foo=10)
+
+        self.assertRaises(
+            AssertionError,
+            nsq.Writer,
+            nsqd_tcp_addresses=['127.0.0.1:4150'],
+            reconnect_interval=15.0,
+            name='test', **bad_options)


### PR DESCRIPTION
Before this change, specifying an invalid keyword argument would cause the AsyncConn
to fail quietly in the Tornado default exception handler during run-time.
