### PR TITLE
Writer._finish_pub() throws an exception if the writer is not connected

### DIFF
--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -200,4 +200,4 @@ class Writer(Client):
     def _finish_pub(self, conn, data, command, topic, msg):
         if isinstance(data, nsq.Error):
             logger.error('[%s] failed to %s (%s, %s), data is %s',
-                          conn.id, command, topic, msg, data)
+                         conn.id if conn else 'NA', command, topic, msg, data)


### PR DESCRIPTION
I'm trying to run some work as soon as the ioloop starts with something like:

```
writer = Writer('nsqd:4150')

def pub_stuff():
  writer.pub('test', 'meep')

tornado.ioloop.IOLoop.current().add_callback(pub_stuff)
nsq.run()
```

I'm getting:

```
ERROR:tornado.application:Exception in callback <functools.partial object at 0x7f130cc6c890>
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/ioloop.py", line 565, in _run_callback
    ret = callback()
  File "/usr/local/lib/python2.7/dist-packages/tornado/stack_context.py", line 275, in null_wrapper
    return fn(*args, **kwargs)
  File "../kisskb/django_kisskb/kisskb3/backend/test2.py", line 9, in pub_stuff
    writer.pub('test', 'meep')
  File "/usr/local/lib/python2.7/dist-packages/nsq/writer.py", line 110, in pub
    self._pub('pub', topic, msg, callback)
  File "/usr/local/lib/python2.7/dist-packages/nsq/writer.py", line 125, in _pub
    callback(None, nsq.SendError('no connections'))
  File "/usr/local/lib/python2.7/dist-packages/nsq/writer.py", line 203, in _finish_pub
    conn.id, command, topic, msg, data)
AttributeError: 'NoneType' object has no attribute 'id'
```

Obviously I somehow need to arrange for `pub_stuff()` to run after the `Writer` is connected, but in the mean time it'd be good if `_finish_pub()` didn't throw an exception like this.
