### PR TITLE
Reader._redistribute_rdy_state() throws UnboundLocalError if no conn is found

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -583,6 +583,8 @@ class Reader(Client):
         # At a high level, we're trying to mitigate stalls related to low-volume
         # producers when we're unable (by configuration or backoff) to provide a RDY count
         # of (at least) 1 to all of our connections.
+        if not self.conns:
+            return
 
         if self.disabled() or self.backoff_block:
             return


### PR DESCRIPTION
```
WARNING: 2014-09-23 11:51:16,803: [backend:4150] connection closed
INFO: 2014-09-23 11:51:16,803: [backend:4150] attempting to reconnect in 15.00s
ERROR: 2014-09-23 11:51:21,222: Exception in callback <bound method Reader._redistribute_rdy_state of <nsq.reader.Reader object at 0x7faed7898310>>
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/ioloop.py", line 972, in _run
    return self.callback()
  File "/usr/local/lib/python2.7/dist-packages/nsq/reader.py", line 634, in _redistribute_rdy_state
    return conn
UnboundLocalError: local variable 'conn' referenced before assignment
```
