### PR TITLE
Cls issue 70

### DIFF
--- a/nsq/async.py
+++ b/nsq/async.py
@@ -189,6 +189,15 @@ class AsyncConn(EventedMixin):
         self.state = 'DISCONNECTED'
         self.trigger('close', conn=self)
 
+    def send_cls(self):
+        try:
+            self.send(nsq.cls())
+        except Exception, e:
+            self.trigger('error', conn=self,
+                         error=nsq.SendError('failed to send CLS'))
+            return False
+        return True
+        
     def close(self):
         self.stream.close()
 

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -188,15 +188,6 @@ class AsyncConn(EventedMixin):
     def _socket_close(self):
         self.state = 'DISCONNECTED'
         self.trigger('close', conn=self)
-
-    def send_cls(self):
-        try:
-            self.send(nsq.cls())
-        except Exception, e:
-            self.trigger('error', conn=self,
-                         error=nsq.SendError('failed to send CLS'))
-            return False
-        return True
         
     def close(self):
         self.stream.close()
@@ -285,6 +276,16 @@ class AsyncConn(EventedMixin):
         self.rdy = value
         return True
 
+    def send_cls(self):
+        try:
+            self.send(nsq.cls())
+        except Exception, e:
+            self.close()
+            self.trigger('error', conn=self,
+                         error=nsq.SendError('failed to send CLS'))
+            return False
+        return True
+    
     def _on_connect(self, **kwargs):
         identify_data = {
             'short_id': self.short_hostname,

--- a/nsq/client.py
+++ b/nsq/client.py
@@ -88,7 +88,7 @@ class Client(object):
             try:
                 conn.send_cls()
             except Exception, e:
-                logger.warning('[%s:%s] error sending CLS, closing'
+                logger.warning('[%s:%s] error sending CLS, closing',
                                conn.id, self.name)
             conn.close()
     

--- a/nsq/client.py
+++ b/nsq/client.py
@@ -78,3 +78,17 @@ class Client(object):
         :param conn: the :class:`nsq.AsyncConn` over which the heartbeat was received
         """
         pass
+
+    def close(self):
+        """
+        Closes all connections stops all periodic callbacks
+        """
+        
+        for conn in self.conns.values():
+            try:
+                conn.send_cls()
+            except Exception, e:
+                logger.warning('[%s:%s] error sending CLS, closing'
+                               conn.id, self.name)
+            conn.close()
+    

--- a/nsq/nsq.py
+++ b/nsq/nsq.py
@@ -102,6 +102,8 @@ def touch(id):
 def nop():
     return _command('NOP', None)
 
+def cls():
+    return _command('CLS', None)
 
 def pub(topic, data):
     return _command('PUB', data, topic)

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -240,16 +240,11 @@ class Reader(Client):
         """
         Closes all connections stops all periodic callbacks
         """
-        
-        for conn in self.conns.values():
-            try:
-                conn.send_cls()
-            except Exception, e:
-                pass
-            conn.close()
-
         self.redist_periodic.stop()
         self.query_periodic.stop()
+        
+        super(Reader, self).close()
+
 
     def set_message_handler(self, message_handler):
         """

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -240,7 +240,12 @@ class Reader(Client):
         """
         Closes all connections stops all periodic callbacks
         """
+        
         for conn in self.conns.values():
+            try:
+                conn.send_cls()
+            except Exception, e:
+                pass
             conn.close()
 
         self.redist_periodic.stop()


### PR DESCRIPTION
Attempting to handle issue #70 by building on @jonesetc close patch in issue #100 to fold in a CLS message back to the nsqd.
- Adds a cls message
- Adds send_cls method to async conn
- Adds close method to the Client class, now you can close Publishers too
- Subsequently tweaks the Reader class

Close stuff happens in a lot of places, probably missed something.

I need to figure out how to roll in some tests as well.
