### PR TITLE
Specify install_requires in setup.py for installation of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,13 @@ setup(
     keywords='python nsq',
     author='Matt Reiferson',
     author_email='snakes@gmail.com',
-    url='http://github.com/bitly/pynsq',
+    url='https://github.com/bitly/pynsq',
     download_url=(
         'https://s3.amazonaws.com/bitly-downloads/nsq/pynsq-%s.tar.gz' %
         version
     ),
     packages=['nsq'],
-    requires=['tornado'],
+    install_requires=['tornado'],
     include_package_data=True,
     zip_safe=False,
     tests_require=['pytest', 'mock', 'tornado'],


### PR DESCRIPTION
`pip install pynsq` or a local equivalent using `setup.py` does not install Tornado. It needs to be specified in `install_requires`. I've specified `tornado>=2.4.1` because this is the oldest version checked on CI.
