### PR TITLE
Use constants for string/byte literals

### DIFF
--- a/nsq/event.py
+++ b/nsq/event.py
@@ -11,11 +11,35 @@ class InvalidListenerError(Exception):
     pass
 
 
+# events
+CONNECT = 'connect'
+CLOSE = 'close'
+DATA = 'data'
+ERROR = 'error'
+IDENTIFY = 'identify'
+READY = 'ready'
+RESPONSE = 'response'
+MESSAGE = 'message'
+HEARTBEAT = 'heartbeat'
+BACKOFF = 'backoff'
+CONTINUE = 'continue'
+RESUME = 'resume'
+REQUEUE = 'requeue'
+TOUCH = 'touch'
+FINISH = 'finish'
+MESSAGE = 'message'
+AUTH = 'auth'
+AUTH_RESPONSE = 'auth_response'
+IDENTIFY_RESPONSE = 'identify_response'
+
+
 class EventedMixin(object):
     """
-    Provides methods to trigger and listen for arbitrary events named as strings.
+    Provides methods to trigger and listen for arbitrary events named as
+    strings.
     """
-    def __init__(self, *args, **kwargs):
+
+    def __init__(self):
         self.__listeners = defaultdict(list)
 
     def on(self, name, callback):

--- a/nsq/message.py
+++ b/nsq/message.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
-from .evented_mixin import EventedMixin
+from nsq import event
 
 
-class Message(EventedMixin):
+class Message(event.EventedMixin):
     """
     A class representing a message received from ``nsqd``.
 
@@ -86,7 +86,7 @@ class Message(EventedMixin):
         """
         assert not self._has_responded
         self._has_responded = True
-        self.trigger('finish', message=self)
+        self.trigger(event.FINISH, message=self)
 
     def requeue(self, **kwargs):
         """
@@ -102,11 +102,11 @@ class Message(EventedMixin):
         """
         assert not self._has_responded
         self._has_responded = True
-        self.trigger('requeue', message=self, **kwargs)
+        self.trigger(event.REQUEUE, message=self, **kwargs)
 
     def touch(self):
         """
         Respond to ``nsqd`` that you need more time to process the message.
         """
         assert not self._has_responded
-        self.trigger('touch', message=self)
+        self.trigger(event.TOUCH, message=self)

--- a/nsq/nsq.py
+++ b/nsq/nsq.py
@@ -14,9 +14,23 @@ from .message import Message
 MAGIC_V2 = '  V2'
 NL = '\n'
 
+
 FRAME_TYPE_RESPONSE = 0
 FRAME_TYPE_ERROR = 1
 FRAME_TYPE_MESSAGE = 2
+
+
+# commmands
+AUTH = 'AUTH'
+FIN = 'FIN'  # success
+IDENTIFY = 'IDENTIFY'
+MPUB = 'MPUB'
+NOP = 'NOP'
+PUB = 'PUB'  # publish
+RDY = 'RDY'
+REQ = 'REQ'  # requeue
+SUB = 'SUB'
+TOUCH = 'TOUCH'
 
 
 class Error(Exception):
@@ -71,42 +85,42 @@ def _command(cmd, body, *params):
 def subscribe(topic, channel):
     assert valid_topic_name(topic)
     assert valid_channel_name(channel)
-    return _command('SUB', None, topic, channel)
+    return _command(SUB, None, topic, channel)
 
 
 def identify(data):
-    return _command('IDENTIFY', json.dumps(data))
+    return _command(IDENTIFY, json.dumps(data))
 
 
 def auth(data):
-    return _command('AUTH', data)
+    return _command(AUTH, data)
 
 
 def ready(count):
     assert isinstance(count, int), 'ready count must be an integer'
     assert count >= 0, 'ready count cannot be negative'
-    return _command('RDY', None, str(count))
+    return _command(RDY, None, str(count))
 
 
 def finish(id):
-    return _command('FIN', None, id)
+    return _command(FIN, None, id)
 
 
 def requeue(id, time_ms=0):
     assert isinstance(time_ms, int), 'requeue time_ms must be an integer'
-    return _command('REQ', None, id, str(time_ms))
+    return _command(REQ, None, id, str(time_ms))
 
 
 def touch(id):
-    return _command('TOUCH', None, id)
+    return _command(TOUCH, None, id)
 
 
 def nop():
-    return _command('NOP', None)
+    return _command(NOP, None)
 
 
 def pub(topic, data):
-    return _command('PUB', data, topic)
+    return _command(PUB, data, topic)
 
 
 def mpub(topic, data):
@@ -114,7 +128,7 @@ def mpub(topic, data):
     body = struct.pack('>l', len(data))
     for m in data:
         body += struct.pack('>l', len(m)) + m
-    return _command('MPUB', body, topic)
+    return _command(MPUB, body, topic)
 
 
 def _is_valid_name(name):


### PR DESCRIPTION
Patch to support #107. 

This moves string/byte literals to constants. 

This is more reliable to maintain, and 2/3 compatibility can be accomplished with one call to `six.b` or equivalent on import of a module rather than an unnecessary function call during runtime whenever a literal is used.
