### PR TITLE
Add SIGINT handler

### DIFF
--- a/nsq/__init__.py
+++ b/nsq/__init__.py
@@ -44,6 +44,7 @@ def run():
     Starts any instantiated :class:`nsq.Reader` or :class:`nsq.Writer`
     """
     signal.signal(signal.SIGTERM, _handle_term_signal)
+    signal.signal(signal.SIGINT, _handle_term_signal)
     tornado.ioloop.IOLoop.instance().start()
 
 


### PR DESCRIPTION
This adds in a SIGINT handler, to ensure that ctrl-c, is caught in the
nsq.run() loop.

@mreiferson this is a follow up from our conversation, let me know if there's anything else you'd like to see documented and/or anything else that needs to be done to get this pushed through.