### PR TITLE
Snappy socket undeclared variable

### DIFF
--- a/nsq/snappy_socket.py
+++ b/nsq/snappy_socket.py
@@ -31,8 +31,7 @@ class SnappySocket(object):
             self._bootstrapped = None
             return data
         chunk = method(size)
-        if chunk:
-            uncompressed = self._decompressor.decompress(chunk)
+        uncompressed = self._decompressor.decompress(chunk) if chunk else None
         if not uncompressed:
             raise socket.error(errno.EWOULDBLOCK)
         return uncompressed


### PR DESCRIPTION
I'm not sure how to reproduce this issue. I am using snappy for writing to nsqd but not when reading, maybe that is what's causing this issue.

WARNING:tornado.general:error on read
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/tornado/iostream.py", line 644, in _handle_read
    pos = self._read_to_buffer_loop()
  File "/usr/local/lib/python2.7/dist-packages/tornado/iostream.py", line 614, in _read_to_buffer_loop
    if self._read_to_buffer() == 0:
  File "/usr/local/lib/python2.7/dist-packages/tornado/iostream.py", line 726, in _read_to_buffer
    chunk = self.read_from_fd()
  File "/usr/local/lib/python2.7/dist-packages/tornado/iostream.py", line 1005, in read_from_fd
    chunk = self.socket.recv(self.read_chunk_size)
  File "/usr/local/lib/python2.7/dist-packages/nsq/snappy_socket.py", line 23, in recv
    return self._recv(size, self._socket.recv)
  File "/usr/local/lib/python2.7/dist-packages/nsq/snappy_socket.py", line 36, in _recv
    if not uncompressed:
UnboundLocalError: local variable 'uncompressed' referenced before assignment