### PR TITLE
remove the signal handler and add a stop function

### DIFF
--- a/nsq/__init__.py
+++ b/nsq/__init__.py
@@ -33,18 +33,16 @@ from .writer import Writer
 from .version import __version__  # NOQA
 
 
-def _handle_term_signal(sig_num, frame):
-    logging.getLogger(__name__).info(
-        'TERM Signal handler called with signal %r', sig_num)
+def stop():
+    """
+    Stop 
+    """
     tornado.ioloop.IOLoop.instance().stop()
-
 
 def run():
     """
     Starts any instantiated :class:`nsq.Reader` or :class:`nsq.Writer`
     """
-    signal.signal(signal.SIGTERM, _handle_term_signal)
-    signal.signal(signal.SIGINT, _handle_term_signal)
     tornado.ioloop.IOLoop.instance().start()
 
 


### PR DESCRIPTION
i think that the signals should be handled by the users themselves. if you capture these signals here, users cannot capture them again.

i am writing a script these days, which fetch messages from nsq and then save to mysql. to impore performance, the program store the messages in an array , and then insert  into mysql at one time when the count achieve 100. so if the program is killed, maybe there are still a batch of messages waiting to be saved to mysql. to  avoid data lost, i should handle the signals myself. but i cannot because these signals are already captured  here.

on the other hand,  i think users should have the ability to stop the nsq manually,  so i add a stop function.