### PR TITLE
set max_rdy_count to value received from IDENTIFY response. see #131

### DIFF
--- a/nsq/async.py
+++ b/nsq/async.py
@@ -410,6 +410,14 @@ class AsyncConn(event.EventedMixin):
         if data.get('auth_required'):
             self._authentication_required = True
 
+        if data.get('max_rdy_count'):
+            self.max_rdy_count = data.get('max_rdy_count')
+        else:
+            # for backwards compatibility when interacting with older nsqd
+            # (pre 0.2.20), default this to their hard-coded max
+            logger.warn('setting max_rdy_count to default value of 2500')
+            self.max_rdy_count = 2500
+
         self.on(event.RESPONSE, self._on_response_continue)
         self._on_response_continue(conn=self, data=None)
 


### PR DESCRIPTION
This fixes the hardcoding of max_rdy_count to 2500 to the value received from the IDENTIFY request. It defaults back to 2500 for older nsq versions. See #131 