### PR TITLE
Tidy up travis_test.sh and ensure tests actually run

### DIFF
--- a/travis_test.sh
+++ b/travis_test.sh
@@ -1,25 +1,42 @@
-#!/bin/bash
+#!/bin/sh
 
+set -eu
 
+install_nsq () {
+    wget "http://bitly-downloads.s3.amazonaws.com/nsq/$NSQ_DOWNLOAD.tar.gz"
+    tar zxvf "$NSQ_DOWNLOAD.tar.gz"
+}
+
+install_snappy () {
+    # install snappy from source so we can compile with `-fPIC` witout having to sudo install stuff
+    git clone https://github.com/google/snappy.git
+    cd snappy
+    sh autogen.sh
+    mkdir -p "$HOME/usr/local"
+    ./configure --prefix="$HOME/usr/local"
+    CFLAGS="-fPIC" make
+    make install
+    cd ..
+}
+
+echo "travis_fold:start:install.nsq"
+install_nsq
+echo "travis_fold:end:install.nsq"
+
+echo "travis_fold:start:install.snappy"
+install_snappy
+echo "travis_fold:end:install.snappy"
+
+echo "travis_fold:start:install.pythondeps"
 pip install simplejson
-export PYCURL_SSL_LIBRARY=openssl
-pip install pycurl
-pip install tornado==$TORNADO_VERSION
-
-# install snappy from source so we can compile with `-fPIC` witout having to sudo install stuff
-git clone https://github.com/google/snappy.git
-cd snappy
-sh autogen.sh
-mkdir $HOME/usr/local
-./configure --prefix=$HOME/usr/local
-CFLAGS="-fPIC" make
-make install
-
-set -e
-
+pip install tornado=="$TORNADO_VERSION"
+PYCURL_SSL_LIBRARY=openssl pip install pycurl
 CPPFLAGS="-I$HOME/usr/local/include -L$HOME/usr/local/lib -fPIC" pip install python-snappy
-wget http://bitly-downloads.s3.amazonaws.com/nsq/$NSQ_DOWNLOAD.tar.gz
-tar zxvf $NSQ_DOWNLOAD.tar.gz
-export PATH=$NSQ_DOWNLOAD/bin:$PATH
+echo "travis_fold:end:install.pythondeps"
 
-LD_LIBRARY_PATH=$HOME/usr/local/lib py.test -q -v
+# Finally, run some tests!
+export PATH=$NSQ_DOWNLOAD/bin:$PATH
+export LD_LIBRARY_PATH=$HOME/usr/local/lib
+
+cd "$TRAVIS_BUILD_DIR"
+py.test


### PR DESCRIPTION
Currently, the tests aren't running on Travis, as we `cd snappy` and never `cd ..`, meaning that py.test discovery doesn't find any tests to run.

This commit tidies up the `travis_test.sh` script a little, improves the output on Travis by folding non-test-related output, and ensures that we're in the correct directory when we run py.test.