### PR TITLE
Python 3 compatibility, round two

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 2.6
   - 2.7
+  - 3.5
 env:
   - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=3.2
   - NSQ_DOWNLOAD=nsq-0.3.0.linux-amd64.go1.3.3 TORNADO_VERSION=4.1

--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -15,6 +15,9 @@ if not PY2:
     text_type = str
     string_types = (str,)
 
+    itervalues = lambda d, *args, **kwargs: d.values(*args, **kwargs)
+    iteritems = lambda d, *args, **kwargs: d.items(*args, **kwargs)
+
     def to_bytes(x, charset='utf-8', errors='strict'):
         if isinstance(x, (bytes, bytearray, memoryview)):
             return bytes(x)
@@ -25,6 +28,9 @@ if not PY2:
 else:
     text_type = unicode
     string_types = (str, unicode)
+
+    itervalues = lambda d, *args, **kwargs: d.itervalues(*args, **kwargs)
+    iteritems = lambda d, *args, **kwargs: d.iteritems(*args, **kwargs)
 
     def to_bytes(x, charset='utf-8', errors='strict'):
         if isinstance(x, (bytes, bytearray, buffer)):

--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -14,6 +14,7 @@ PY2 = sys.version_info[0] == 2
 if not PY2:
     text_type = str
     string_types = (str,)
+    integer_types = (int,)
 
     itervalues = lambda d, *args, **kwargs: d.values(*args, **kwargs)
     iteritems = lambda d, *args, **kwargs: d.items(*args, **kwargs)
@@ -28,6 +29,7 @@ if not PY2:
 else:
     text_type = unicode
     string_types = (str, unicode)
+    integer_types = (int, long)
 
     itervalues = lambda d, *args, **kwargs: d.itervalues(*args, **kwargs)
     iteritems = lambda d, *args, **kwargs: d.iteritems(*args, **kwargs)

--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+import struct
 import sys
 
 PY2 = sys.version_info[0] == 2
@@ -27,6 +28,12 @@ if not PY2:
             return x.encode(charset, errors)
         raise TypeError('expected bytes or a string, not %r' % type(x))
 
+    def struct_pack(fmt, *values):
+        return struct.pack(fmt, *values)
+
+    def struct_unpack(fmt, string):
+        return struct.unpack(fmt, string)
+
 else:
     bytes_types = (bytes, bytearray, buffer)
     text_type = unicode
@@ -42,6 +49,15 @@ else:
         if isinstance(x, unicode):
             return x.encode(charset, errors)
         raise TypeError('expected bytes or a string, not %r' % type(x))
+
+    # Python 2.6 has the rather unfortunate problem of raising a TypeError if
+    # you pass a unicode object as the `fmt` parameter. This shim can be
+    # removed when support for Python earlier than 2.7 is dropped.
+    def struct_pack(fmt, *values):
+        return struct.pack(str(fmt), *values)
+
+    def struct_unpack(fmt, string):
+        return struct.unpack(str(fmt), string)
 
 try:
     from urllib import parse as urlparse

--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -1,0 +1,34 @@
+# flake8: noqa
+
+import sys
+
+PY2 = sys.version_info[0] == 2
+
+# N.B. In each of the stanzas below, the first conditional branch represents
+# Python 3 and higher. The fallback is Python 2.
+#
+# Don't ever check to see if the Python major version is 3, as such code will
+# then immediately break if and when Python 4 is ever released. Instead, assume
+# that Python 2 is the odd child, and make an exception accordingly.
+
+if not PY2:
+    text_type = str
+    string_types = (str,)
+
+    def to_bytes(x, charset='utf-8', errors='strict'):
+        if isinstance(x, (bytes, bytearray, memoryview)):
+            return bytes(x)
+        if isinstance(x, str):
+            return x.encode(charset, errors)
+        raise TypeError('expected bytes or a string, not %r' % type(x))
+
+else:
+    text_type = unicode
+    string_types = (str, unicode)
+
+    def to_bytes(x, charset='utf-8', errors='strict'):
+        if isinstance(x, (bytes, bytearray, buffer)):
+            return bytes(x)
+        if isinstance(x, unicode):
+            return x.encode(charset, errors)
+        raise TypeError('expected bytes or a string, not %r' % type(x))

--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -12,6 +12,7 @@ PY2 = sys.version_info[0] == 2
 # that Python 2 is the odd child, and make an exception accordingly.
 
 if not PY2:
+    bytes_types = (bytes, bytearray, memoryview)
     text_type = str
     string_types = (str,)
     integer_types = (int,)
@@ -20,13 +21,14 @@ if not PY2:
     iteritems = lambda d, *args, **kwargs: d.items(*args, **kwargs)
 
     def to_bytes(x, charset='utf-8', errors='strict'):
-        if isinstance(x, (bytes, bytearray, memoryview)):
+        if isinstance(x, bytes_types):
             return bytes(x)
         if isinstance(x, str):
             return x.encode(charset, errors)
         raise TypeError('expected bytes or a string, not %r' % type(x))
 
 else:
+    bytes_types = (bytes, bytearray, buffer)
     text_type = unicode
     string_types = (str, unicode)
     integer_types = (int, long)
@@ -35,7 +37,7 @@ else:
     iteritems = lambda d, *args, **kwargs: d.iteritems(*args, **kwargs)
 
     def to_bytes(x, charset='utf-8', errors='strict'):
-        if isinstance(x, (bytes, bytearray, buffer)):
+        if isinstance(x, bytes_types):
             return bytes(x)
         if isinstance(x, unicode):
             return x.encode(charset, errors)

--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -32,3 +32,10 @@ else:
         if isinstance(x, unicode):
             return x.encode(charset, errors)
         raise TypeError('expected bytes or a string, not %r' % type(x))
+
+try:
+    from urllib import parse as urlparse
+    from urllib.parse import urlencode
+except ImportError:
+    import urlparse
+    from urllib import urlencode

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import time
 import socket
@@ -381,12 +382,12 @@ class AsyncConn(event.EventedMixin):
     def _on_identify_response(self, data, **kwargs):
         self.off(event.RESPONSE, self._on_identify_response)
 
-        if data == 'OK':
+        if data == b'OK':
             logger.warning('nsqd version does not support feature netgotiation')
             return self.trigger(event.READY, conn=self)
 
         try:
-            data = json.loads(data)
+            data = json.loads(data.decode('utf-8'))
         except ValueError:
             self.close()
             self.trigger(
@@ -452,7 +453,7 @@ class AsyncConn(event.EventedMixin):
 
     def _on_auth_response(self, data, **kwargs):
         try:
-            data = json.loads(data)
+            data = json.loads(data.decode('utf-8'))
         except ValueError:
             self.close()
             self.trigger(
@@ -482,7 +483,7 @@ class AsyncConn(event.EventedMixin):
             message.on(event.TOUCH, self._on_message_touch)
 
             self.trigger(event.MESSAGE, conn=self, message=message)
-        elif frame == protocol.FRAME_TYPE_RESPONSE and data == '_heartbeat_':
+        elif frame == protocol.FRAME_TYPE_RESPONSE and data == b'_heartbeat_':
             self.send(protocol.nop())
             self.trigger(event.HEARTBEAT, conn=self)
         elif frame == protocol.FRAME_TYPE_RESPONSE:

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -5,6 +5,7 @@ import socket
 import struct
 import logging
 
+from ._compat import string_types
 from .version import __version__
 
 try:
@@ -146,7 +147,7 @@ class AsyncConn(event.EventedMixin):
             io_loop=None,
             auth_secret=None,
             msg_timeout=None):
-        assert isinstance(host, (str, unicode))
+        assert isinstance(host, string_types)
         assert isinstance(port, int)
         assert isinstance(timeout, float)
         assert isinstance(tls_options, (dict, None.__class__))
@@ -156,7 +157,7 @@ class AsyncConn(event.EventedMixin):
         assert isinstance(output_buffer_size, int) and output_buffer_size >= 0
         assert isinstance(output_buffer_timeout, int) and output_buffer_timeout >= 0
         assert isinstance(sample_rate, int) and sample_rate >= 0 and sample_rate < 100
-        assert isinstance(auth_secret, (str, unicode, None.__class__))
+        assert isinstance(auth_secret, string_types + (None.__class__,))
         assert tls_v1 and ssl or not tls_v1, \
             'tls_v1 requires Python 2.6+ or Python 2.5 w/ pip install ssl'
         assert msg_timeout is None or (isinstance(msg_timeout, (float, int)) and msg_timeout > 0)

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 
 import time
 import socket
-import struct
 import logging
 
 from ._compat import string_types
+from ._compat import struct_unpack
 from .version import __version__
 
 try:
@@ -261,7 +261,7 @@ class AsyncConn(event.EventedMixin):
 
     def _read_size(self, data):
         try:
-            size = struct.unpack('>l', data)[0]
+            size = struct_unpack('>l', data)[0]
         except Exception:
             self.close()
             self.trigger(

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -336,7 +336,7 @@ class AsyncConn(event.EventedMixin):
     def send_rdy(self, value):
         try:
             self.send(protocol.ready(value))
-        except Exception, e:
+        except Exception as e:
             self.close()
             self.trigger(
                 event.ERROR,
@@ -369,7 +369,7 @@ class AsyncConn(event.EventedMixin):
         self.on(event.RESPONSE, self._on_identify_response)
         try:
             self.send(protocol.identify(identify_data))
-        except Exception, e:
+        except Exception as e:
             self.close()
             self.trigger(
                 event.ERROR,
@@ -439,7 +439,7 @@ class AsyncConn(event.EventedMixin):
             self.trigger(event.AUTH, conn=self, data=self.auth_secret)
             try:
                 self.send(protocol.auth(self.auth_secret))
-            except Exception, e:
+            except Exception as e:
                 self.close()
                 self.trigger(
                     event.ERROR,
@@ -499,7 +499,7 @@ class AsyncConn(event.EventedMixin):
         try:
             time_ms = self.requeue_delay * message.attempts * 1000 if time_ms < 0 else time_ms
             self.send(protocol.requeue(message.id, time_ms))
-        except Exception, e:
+        except Exception as e:
             self.close()
             self.trigger(event.ERROR, conn=self, error=protocol.SendError(
                 'failed to send REQ %s @ %d' % (message.id, time_ms), e))
@@ -510,7 +510,7 @@ class AsyncConn(event.EventedMixin):
         self.in_flight -= 1
         try:
             self.send(protocol.finish(message.id))
-        except Exception, e:
+        except Exception as e:
             self.close()
             self.trigger(
                 event.ERROR,
@@ -521,7 +521,7 @@ class AsyncConn(event.EventedMixin):
     def _on_message_touch(self, message, **kwargs):
         try:
             self.send(protocol.touch(message.id))
-        except Exception, e:
+        except Exception as e:
             self.close()
             self.trigger(
                 event.ERROR,

--- a/nsq/protocol.py
+++ b/nsq/protocol.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 import struct
 import re
 
@@ -7,28 +8,29 @@ try:
 except ImportError:
     import json  # pyflakes.ignore
 
-from ._compat import text_type
+from ._compat import bytes_types
+from ._compat import to_bytes
 from .message import Message
 
-MAGIC_V2 = '  V2'
-NL = '\n'
+MAGIC_V2 = b'  V2'
+NL = b'\n'
 
 FRAME_TYPE_RESPONSE = 0
 FRAME_TYPE_ERROR = 1
 FRAME_TYPE_MESSAGE = 2
 
 # commmands
-AUTH = 'AUTH'
-FIN = 'FIN'  # success
-IDENTIFY = 'IDENTIFY'
-MPUB = 'MPUB'
-NOP = 'NOP'
-PUB = 'PUB'  # publish
-RDY = 'RDY'
-REQ = 'REQ'  # requeue
-SUB = 'SUB'
-TOUCH = 'TOUCH'
-DPUB = 'DPUB'  # deferred publish
+AUTH = b'AUTH'
+FIN = b'FIN'  # success
+IDENTIFY = b'IDENTIFY'
+MPUB = b'MPUB'
+NOP = b'NOP'
+PUB = b'PUB'  # publish
+RDY = b'RDY'
+REQ = b'REQ'  # requeue
+SUB = b'SUB'
+TOUCH = b'TOUCH'
+DPUB = b'DPUB'  # deferred publish
 
 
 class Error(Exception):
@@ -68,15 +70,16 @@ def decode_message(data):
 
 
 def _command(cmd, body, *params):
-    body_data = ''
-    params_data = ''
+    body_data = b''
+    params_data = b''
     if body:
-        assert isinstance(body, str), 'body must be a string'
-        body_data = struct.pack('>l', len(body)) + body
+        assert isinstance(body, bytes_types), 'body must be a bytestring'
+        body_bytes = to_bytes(body)  # raises if not convertible to bytes
+        body_data = struct.pack('>l', len(body)) + body_bytes
     if len(params):
-        params = [p.encode('utf-8') if isinstance(p, text_type) else p for p in params]
-        params_data = ' ' + ' '.join(params)
-    return '%s%s%s%s' % (cmd, params_data, NL, body_data)
+        params = [to_bytes(p) for p in params]
+        params_data = b' ' + b' '.join(params)
+    return b'%s%s%s%s' % (cmd, params_data, NL, body_data)
 
 
 def subscribe(topic, channel):
@@ -86,7 +89,7 @@ def subscribe(topic, channel):
 
 
 def identify(data):
-    return _command(IDENTIFY, json.dumps(data))
+    return _command(IDENTIFY, to_bytes(json.dumps(data)))
 
 
 def auth(data):
@@ -124,7 +127,8 @@ def mpub(topic, data):
     assert isinstance(data, (set, list))
     body = struct.pack('>l', len(data))
     for m in data:
-        body += struct.pack('>l', len(m)) + m
+        assert isinstance(m, bytes_types), 'message bodies must be bytestrings'
+        body += struct.pack('>l', len(m)) + to_bytes(m)
     return _command(MPUB, body, topic)
 
 

--- a/nsq/protocol.py
+++ b/nsq/protocol.py
@@ -7,6 +7,7 @@ try:
 except ImportError:
     import json  # pyflakes.ignore
 
+from ._compat import text_type
 from .message import Message
 
 MAGIC_V2 = '  V2'
@@ -73,7 +74,7 @@ def _command(cmd, body, *params):
         assert isinstance(body, str), 'body must be a string'
         body_data = struct.pack('>l', len(body)) + body
     if len(params):
-        params = [p.encode('utf-8') if isinstance(p, unicode) else p for p in params]
+        params = [p.encode('utf-8') if isinstance(p, text_type) else p for p in params]
         params_data = ' ' + ' '.join(params)
     return '%s%s%s%s' % (cmd, params_data, NL, body_data)
 

--- a/nsq/protocol.py
+++ b/nsq/protocol.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import struct
 import re
 
 try:
@@ -10,6 +9,7 @@ except ImportError:
 
 from ._compat import bytes_types
 from ._compat import to_bytes
+from ._compat import struct_pack, struct_unpack
 from .message import Message
 
 MAGIC_V2 = b'  V2'
@@ -57,13 +57,13 @@ class IntegrityError(Error):
 
 
 def unpack_response(data):
-    frame = struct.unpack('>l', data[:4])[0]
+    frame = struct_unpack('>l', data[:4])[0]
     return frame, data[4:]
 
 
 def decode_message(data):
-    timestamp = struct.unpack('>q', data[:8])[0]
-    attempts = struct.unpack('>h', data[8:10])[0]
+    timestamp = struct_unpack('>q', data[:8])[0]
+    attempts = struct_unpack('>h', data[8:10])[0]
     id = data[10:26]
     body = data[26:]
     return Message(id, body, timestamp, attempts)
@@ -75,7 +75,7 @@ def _command(cmd, body, *params):
     if body:
         assert isinstance(body, bytes_types), 'body must be a bytestring'
         body_bytes = to_bytes(body)  # raises if not convertible to bytes
-        body_data = struct.pack('>l', len(body)) + body_bytes
+        body_data = struct_pack('>l', len(body)) + body_bytes
     if len(params):
         params = [to_bytes(p) for p in params]
         params_data = b' ' + b' '.join(params)
@@ -125,10 +125,10 @@ def pub(topic, data):
 
 def mpub(topic, data):
     assert isinstance(data, (set, list))
-    body = struct.pack('>l', len(data))
+    body = struct_pack('>l', len(data))
     for m in data:
         assert isinstance(m, bytes_types), 'message bodies must be bytestrings'
-        body += struct.pack('>l', len(m)) + to_bytes(m)
+        body += struct_pack('>l', len(m)) + to_bytes(m)
     return _command(MPUB, body, topic)
 
 

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -727,7 +727,7 @@ class Reader(Client):
                         return int(x)
                     except:
                         return x
-                return map(cast, v.replace('-','.').split('.'))
+                return [cast(x) for x in v.replace('-','.').split('.')]
 
             if self.disabled.__code__ != Reader.disabled.__code__ and semver(data['version']) >= semver('0.3'):
                 logging.warning('disabled() deprecated and incompatible with nsqd >= 0.3. ' + 

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -376,7 +376,7 @@ class Reader(Client):
         if not self.conns or self.max_in_flight == 0:
             return
 
-        conn = random.choice(self.conns.values())
+        conn = random.choice(list(self.conns.values()))
         logger.info('[%s:%s] testing backoff state with RDY 1', conn.id, self.name)
         self._send_rdy(conn, 1)
 
@@ -681,7 +681,7 @@ class Reader(Client):
             # We also don't attempt to avoid the connections who previously might have had RDY 1
             # because it would be overly complicated and not actually worth it (ie. given enough
             # redistribution rounds it doesn't matter).
-            possible_conns = self.conns.values()
+            possible_conns = list(self.conns.values())
             while possible_conns and max_in_flight:
                 max_in_flight -= 1
                 conn = possible_conns.pop(random.randrange(len(possible_conns)))

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -16,6 +16,8 @@ except ImportError:
 from tornado.ioloop import PeriodicCallback
 import tornado.httpclient
 
+from ._compat import iteritems
+from ._compat import itervalues
 from ._compat import string_types
 from ._compat import to_bytes
 from ._compat import urlencode
@@ -301,7 +303,7 @@ class Reader(Client):
             reader.set_message_handler(functools.partial(message_handler, reader=reader))
             nsq.run()
         """
-        for conn in self.conns.itervalues():
+        for conn in itervalues(self.conns):
             if conn.in_flight > 0 and conn.in_flight >= (conn.last_rdy * 0.85):
                 return True
         return False
@@ -320,7 +322,7 @@ class Reader(Client):
             # if all connections aren't getting RDY
             # occsionally randomize which connection gets RDY
             self.random_rdy_ts = time.time()
-            conns_with_no_rdy = [c for c in self.conns.itervalues() if not c.rdy]
+            conns_with_no_rdy = [c for c in itervalues(self.conns) if not c.rdy]
             if conns_with_no_rdy:
                 rdy_conn = random.choice(conns_with_no_rdy)
                 if rdy_conn is not conn:
@@ -614,7 +616,7 @@ class Reader(Client):
         
         if max_in_flight == 0:
             # set RDY 0 to all connections
-            for conn in self.conns.itervalues():
+            for conn in itervalues(self.conns):
                 if conn.rdy > 0:
                     logger.debug('[%s:%s] rdy: %d -> 0', conn.id, self.name, conn.rdy)
                     self._send_rdy(conn, 0)
@@ -657,7 +659,7 @@ class Reader(Client):
 
             # first set RDY 0 to all connections that have not received a message within
             # a configurable timeframe (low_rdy_idle_timeout).
-            for conn_id, conn in self.conns.iteritems():
+            for conn_id, conn in iteritems(self.conns):
                 last_message_duration = time.time() - conn.last_msg_timestamp
                 logger.debug('[%s:%s] rdy: %d (last message received %.02fs)',
                              conn.id, self.name, conn.rdy, last_message_duration)

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -3,9 +3,7 @@ from __future__ import absolute_import
 import logging
 import time
 import functools
-import urllib
 import random
-import urlparse
 import cgi
 import warnings
 import inspect
@@ -20,6 +18,8 @@ import tornado.httpclient
 
 from ._compat import string_types
 from ._compat import to_bytes
+from ._compat import urlencode
+from ._compat import urlparse
 from .backoff_timer import BackoffTimer
 from .client import Client
 from . import protocol
@@ -573,7 +573,7 @@ class Reader(Client):
 
         params = cgi.parse_qs(query)
         params['topic'] = self.topic
-        query = urllib.urlencode(_utf8_params(params), doseq=1)
+        query = urlencode(_utf8_params(params), doseq=1)
         lookupd_url = urlparse.urlunsplit((scheme, netloc, path, query, fragment))
 
         req = tornado.httpclient.HTTPRequest(

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import division
 
 import logging
 import time
@@ -281,7 +282,7 @@ class Reader(Client):
         self.message_handler = message_handler
 
     def _connection_max_in_flight(self):
-        return max(1, self.max_in_flight / max(1, len(self.conns)))
+        return max(1, self.max_in_flight // max(1, len(self.conns)))
 
     def is_starved(self):
         """

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -18,6 +18,8 @@ except ImportError:
 from tornado.ioloop import PeriodicCallback
 import tornado.httpclient
 
+from ._compat import string_types
+from ._compat import to_bytes
 from .backoff_timer import BackoffTimer
 from .client import Client
 from . import protocol
@@ -152,11 +154,11 @@ class Reader(Client):
             **kwargs):
         super(Reader, self).__init__(**kwargs)
 
-        assert isinstance(topic, (str, unicode)) and len(topic) > 0
-        assert isinstance(channel, (str, unicode)) and len(channel) > 0
+        assert isinstance(topic, string_types) and len(topic) > 0
+        assert isinstance(channel, string_types) and len(channel) > 0
         assert isinstance(max_in_flight, int) and max_in_flight > 0
         assert isinstance(max_backoff_duration, (int, float)) and max_backoff_duration > 0
-        assert isinstance(name, (str, unicode, None.__class__))
+        assert isinstance(name, string_types + (None.__class__,))
         assert isinstance(lookupd_poll_interval, int)
         assert isinstance(lookupd_poll_jitter, float)
         assert isinstance(lookupd_connect_timeout, int)
@@ -166,14 +168,14 @@ class Reader(Client):
 
         if nsqd_tcp_addresses:
             if not isinstance(nsqd_tcp_addresses, (list, set, tuple)):
-                assert isinstance(nsqd_tcp_addresses, (str, unicode))
+                assert isinstance(nsqd_tcp_addresses, string_types)
                 nsqd_tcp_addresses = [nsqd_tcp_addresses]
         else:
             nsqd_tcp_addresses = []
 
         if lookupd_http_addresses:
             if not isinstance(lookupd_http_addresses, (list, set, tuple)):
-                assert isinstance(lookupd_http_addresses, (str, unicode))
+                assert isinstance(lookupd_http_addresses, string_types)
                 lookupd_http_addresses = [lookupd_http_addresses]
             random.shuffle(lookupd_http_addresses)
         else:
@@ -464,7 +466,7 @@ class Reader(Client):
         :param host: the address to connect to
         :param port: the port to connect to
         """
-        assert isinstance(host, (str, unicode))
+        assert isinstance(host, string_types)
         assert isinstance(port, int)
 
         conn = async.AsyncConn(host, port, **self.conn_kwargs)
@@ -761,16 +763,8 @@ def _utf8_params(params):
         if isinstance(v, (int, long, float)):
             v = str(v)
         if isinstance(v, (list, tuple)):
-            v = [_utf8(x) for x in v]
+            v = [to_bytes(x) for x in v]
         else:
-            v = _utf8(v)
+            v = to_bytes(v)
         encoded_params.append((k, v))
     return dict(encoded_params)
-
-
-def _utf8(s):
-    """encode a unicode string as utf-8"""
-    if isinstance(s, unicode):
-        return s.encode("utf-8")
-    assert isinstance(s, str), "_utf8 expected a str, not %r" % type(s)
-    return s

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -16,6 +16,7 @@ except ImportError:
 from tornado.ioloop import PeriodicCallback
 import tornado.httpclient
 
+from ._compat import integer_types
 from ._compat import iteritems
 from ._compat import itervalues
 from ._compat import string_types
@@ -762,7 +763,7 @@ def _utf8_params(params):
     for k, v in params.items():
         if v is None:
             continue
-        if isinstance(v, (int, long, float)):
+        if isinstance(v, integer_types + (float,)):
             v = str(v)
         if isinstance(v, (list, tuple)):
             v = [to_bytes(x) for x in v]

--- a/nsq/sync.py
+++ b/nsq/sync.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import socket
 import struct
 
+from nsq._compat import string_types
 from nsq import protocol
 
 
@@ -13,7 +14,7 @@ class SyncConn(object):
         self.s = None
 
     def connect(self, host, port):
-        assert isinstance(host, (str, unicode))
+        assert isinstance(host, string_types)
         assert isinstance(port, int)
         self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.s.settimeout(self.timeout)

--- a/nsq/sync.py
+++ b/nsq/sync.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import socket
 import struct
@@ -9,7 +10,7 @@ from nsq import protocol
 
 class SyncConn(object):
     def __init__(self, timeout=1.0):
-        self.buffer = ''
+        self.buffer = b''
         self.timeout = timeout
         self.s = None
 

--- a/nsq/sync.py
+++ b/nsq/sync.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import socket
-import struct
 
 from nsq._compat import string_types
+from nsq._compat import struct_unpack
 from nsq import protocol
 
 
@@ -35,7 +35,7 @@ class SyncConn(object):
         return data
 
     def read_response(self):
-        size = struct.unpack('>l', self._readn(4))[0]
+        size = struct_unpack('>l', self._readn(4))[0]
         return self._readn(size)
 
     def send(self, data):

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -30,7 +30,7 @@ class Writer(Client):
             writer.pub('test', time.strftime('%H:%M:%S'), finish_pub)
 
         def finish_pub(conn, data):
-            print data
+            print(data)
 
         writer = nsq.Writer(['127.0.0.1:4150'])
         tornado.ioloop.PeriodicCallback(pub_message, 1000).start()

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -132,7 +132,7 @@ class Writer(Client):
             callback(None, protocol.SendError('no connections'))
             return
 
-        conn = random.choice(self.conns.values())
+        conn = random.choice(list(self.conns.values()))
         conn.callback_queue.append(callback)
         cmd = getattr(protocol, command)
 

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -7,6 +7,7 @@ import functools
 import random
 import inspect
 
+from ._compat import string_types
 from .client import Client
 from nsq import protocol
 from . import async
@@ -86,7 +87,7 @@ class Writer(Client):
         super(Writer, self).__init__(**kwargs)
 
         if not isinstance(nsqd_tcp_addresses, (list, set, tuple)):
-            assert isinstance(nsqd_tcp_addresses, (str, unicode))
+            assert isinstance(nsqd_tcp_addresses, string_types)
             nsqd_tcp_addresses = [nsqd_tcp_addresses]
         assert nsqd_tcp_addresses
 
@@ -113,7 +114,7 @@ class Writer(Client):
         self._pub('pub', topic, msg, callback=callback)
 
     def mpub(self, topic, msg, callback=None):
-        if isinstance(msg, (str, unicode)):
+        if isinstance(msg, string_types):
             msg = [msg]
         assert isinstance(msg, (list, set, tuple))
 
@@ -163,7 +164,7 @@ class Writer(Client):
             self.connect_to_nsqd(host, int(port))
 
     def connect_to_nsqd(self, host, port):
-        assert isinstance(host, (str, unicode))
+        assert isinstance(host, string_types)
         assert isinstance(port, int)
 
         conn = async.AsyncConn(host, port, **self.conn_kwargs)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -4,7 +4,6 @@ from __future__ import with_statement
 import os
 import sys
 
-import struct
 from mock import patch, create_autospec, MagicMock
 from tornado.iostream import IOStream
 
@@ -13,6 +12,7 @@ base_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__
 if base_dir not in sys.path:
     sys.path.insert(0, base_dir)
 
+from nsq._compat import struct_pack
 from nsq.async import AsyncConn
 from nsq import protocol
 
@@ -80,7 +80,7 @@ def test_start_read():
 def test_read_size():
     conn = _get_test_conn()
     body_size = 6
-    body_size_packed = struct.pack('>l', body_size)
+    body_size_packed = struct_pack('>l', body_size)
     conn._read_size(body_size_packed)
     conn.stream.read_bytes.assert_called_once_with(body_size, conn._read_body)
 

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import with_statement
+from __future__ import unicode_literals
 
 import os
 import sys
@@ -78,7 +79,7 @@ def test_backoff_easy():
     timeout_args[1]()
     assert r.backoff_block is False
     send_args, send_kwargs = conn.stream.write.call_args
-    assert send_args[0] == 'RDY 1\n'
+    assert send_args[0] == b'RDY 1\n'
 
     msg = _send_message(conn)
 
@@ -87,15 +88,15 @@ def test_backoff_easy():
     assert r.backoff_timer.get_interval() == 0
 
     expected_args = [
-        'SUB test test\n',
-        'RDY 1\n',
-        'RDY 5\n',
-        'FIN 1234\n',
-        'RDY 0\n',
-        'REQ 1234 0\n',
-        'RDY 1\n',
-        'RDY 5\n',
-        'FIN 1234\n'
+        b'SUB test test\n',
+        b'RDY 1\n',
+        b'RDY 5\n',
+        b'FIN 1234\n',
+        b'RDY 0\n',
+        b'REQ 1234 0\n',
+        b'RDY 1\n',
+        b'RDY 5\n',
+        b'FIN 1234\n'
     ]
     assert conn.stream.write.call_args_list == [((arg,),) for arg in expected_args]
 
@@ -131,22 +132,22 @@ def test_backoff_out_of_order():
     assert r.backoff_timer.get_interval() == 0
 
     expected_args = [
-        'SUB test test\n',
-        'RDY 1\n',
-        'RDY 2\n',
-        'FIN 1234\n',
-        'RDY 0\n',
-        'REQ 1234 0\n',
-        'FIN 1234\n',
-        'RDY 2\n',
+        b'SUB test test\n',
+        b'RDY 1\n',
+        b'RDY 2\n',
+        b'FIN 1234\n',
+        b'RDY 0\n',
+        b'REQ 1234 0\n',
+        b'FIN 1234\n',
+        b'RDY 2\n',
     ]
     assert conn1.stream.write.call_args_list == [((arg,),) for arg in expected_args]
 
     expected_args = [
-        'SUB test test\n',
-        'RDY 1\n',
-        'RDY 0\n',
-        'RDY 2\n'
+        b'SUB test test\n',
+        b'RDY 1\n',
+        b'RDY 0\n',
+        b'RDY 2\n'
     ]
     assert conn2.stream.write.call_args_list == [((arg,),) for arg in expected_args]
 
@@ -199,18 +200,18 @@ def test_backoff_requeue_recovery():
     print(conn.stream.write.call_args_list)
 
     expected_args = [
-        'SUB test test\n',
-        'RDY 1\n',
-        'RDY 2\n',
-        'FIN 1234\n',
-        'RDY 0\n',
-        'REQ 1234 0\n',
-        'RDY 1\n',
-        'RDY 0\n',
-        'REQ 1234 0\n',
-        'RDY 1\n',
-        'RDY 2\n',
-        'FIN 1234\n'
+        b'SUB test test\n',
+        b'RDY 1\n',
+        b'RDY 2\n',
+        b'FIN 1234\n',
+        b'RDY 0\n',
+        b'REQ 1234 0\n',
+        b'RDY 1\n',
+        b'RDY 0\n',
+        b'REQ 1234 0\n',
+        b'RDY 1\n',
+        b'RDY 2\n',
+        b'FIN 1234\n'
     ]
     assert conn.stream.write.call_args_list == [((arg,),) for arg in expected_args]
 
@@ -220,7 +221,7 @@ def test_backoff_hard():
     r = _get_reader(io_loop=mock_ioloop)
     conn = _get_conn(r)
 
-    expected_args = ['SUB test test\n', 'RDY 1\n', 'RDY 5\n']
+    expected_args = [b'SUB test test\n', b'RDY 1\n', b'RDY 5\n']
 
     num_fails = 0
     fail = True
@@ -232,14 +233,14 @@ def test_backoff_hard():
             msg.trigger(event.REQUEUE, message=msg)
             num_fails += 1
 
-            expected_args.append('RDY 0\n')
-            expected_args.append('REQ 1234 0\n')
+            expected_args.append(b'RDY 0\n')
+            expected_args.append(b'REQ 1234 0\n')
         else:
             msg.trigger(event.FINISH, message=msg)
             num_fails -= 1
 
-            expected_args.append('RDY 0\n')
-            expected_args.append('FIN 1234\n')
+            expected_args.append(b'RDY 0\n')
+            expected_args.append(b'FIN 1234\n')
 
         assert r.backoff_block is True
         assert r.backoff_timer.get_interval() > 0
@@ -250,7 +251,7 @@ def test_backoff_hard():
             timeout_args[1]()
             last_timeout_time = timeout_args[0]
         assert r.backoff_block is False
-        expected_args.append('RDY 1\n')
+        expected_args.append(b'RDY 1\n')
 
         fail = True
         if random.random() < 0.3 and num_fails > 1:
@@ -260,19 +261,19 @@ def test_backoff_hard():
         msg = _send_message(conn)
 
         msg.trigger(event.FINISH, message=msg)
-        expected_args.append('RDY 0\n')
-        expected_args.append('FIN 1234\n')
+        expected_args.append(b'RDY 0\n')
+        expected_args.append(b'FIN 1234\n')
         timeout_args, timeout_kwargs = mock_ioloop.add_timeout.call_args
         if timeout_args[0] != last_timeout_time:
             timeout_args[1]()
             last_timeout_time = timeout_args[0]
-        expected_args.append('RDY 1\n')
+        expected_args.append(b'RDY 1\n')
 
     msg = _send_message(conn)
 
     msg.trigger(event.FINISH, message=msg)
-    expected_args.append('RDY 5\n')
-    expected_args.append('FIN 1234\n')
+    expected_args.append(b'RDY 5\n')
+    expected_args.append(b'FIN 1234\n')
 
     assert r.backoff_block is False
     assert r.backoff_timer.get_interval() == 0
@@ -290,7 +291,7 @@ def test_backoff_many_conns():
     conns = []
     for i in range(num_conns):
         conn = _get_conn(r)
-        conn.expected_args = ['SUB test test\n', 'RDY 1\n']
+        conn.expected_args = [b'SUB test test\n', b'RDY 1\n']
         conn.fails = 0
         conns.append(conn)
 
@@ -302,7 +303,7 @@ def test_backoff_many_conns():
         msg = _send_message(conn)
 
         if r.backoff_timer.get_interval() == 0:
-            conn.expected_args.append('RDY 1\n')
+            conn.expected_args.append(b'RDY 1\n')
 
         if fail or not conn.fails:
             msg.trigger(event.REQUEUE, message=msg)
@@ -310,16 +311,16 @@ def test_backoff_many_conns():
             conn.fails += 1
 
             for c in conns:
-                c.expected_args.append('RDY 0\n')
-            conn.expected_args.append('REQ 1234 0\n')
+                c.expected_args.append(b'RDY 0\n')
+            conn.expected_args.append(b'REQ 1234 0\n')
         else:
             msg.trigger(event.FINISH, message=msg)
             total_fails -= 1
             conn.fails -= 1
 
             for c in conns:
-                c.expected_args.append('RDY 0\n')
-            conn.expected_args.append('FIN 1234\n')
+                c.expected_args.append(b'RDY 0\n')
+            conn.expected_args.append(b'FIN 1234\n')
 
         assert r.backoff_block is True
         assert r.backoff_timer.get_interval() > 0
@@ -330,7 +331,7 @@ def test_backoff_many_conns():
             conn = timeout_args[1]()
             last_timeout_time = timeout_args[0]
         assert r.backoff_block is False
-        conn.expected_args.append('RDY 1\n')
+        conn.expected_args.append(b'RDY 1\n')
 
         fail = True
         if random.random() < 0.3 and total_fails > 1:
@@ -344,9 +345,9 @@ def test_backoff_many_conns():
             for c in conns:
                 if c.rdy > 0:
                     c.last_msg_timestamp = time.time() - 60
-                    c.expected_args.append('RDY 0\n')
+                    c.expected_args.append(b'RDY 0\n')
             conn = r._redistribute_rdy_state()
-            conn.expected_args.append('RDY 1\n')
+            conn.expected_args.append(b'RDY 1\n')
             continue
 
         msg = _send_message(conn)
@@ -357,12 +358,12 @@ def test_backoff_many_conns():
 
         if total_fails > 0:
             for c in conns:
-                c.expected_args.append('RDY 0\n')
+                c.expected_args.append(b'RDY 0\n')
         else:
             for c in conns:
-                c.expected_args.append('RDY 1\n')
+                c.expected_args.append(b'RDY 1\n')
 
-        conn.expected_args.append('FIN 1234\n')
+        conn.expected_args.append(b'FIN 1234\n')
 
         timeout_args, timeout_kwargs = mock_ioloop.add_timeout.call_args
         if timeout_args[0] != last_timeout_time:
@@ -370,7 +371,7 @@ def test_backoff_many_conns():
             last_timeout_time = timeout_args[0]
 
         if total_fails > 0:
-            conn.expected_args.append('RDY 1\n')
+            conn.expected_args.append(b'RDY 1\n')
 
     assert r.backoff_block is False
     assert r.backoff_timer.get_interval() == 0
@@ -389,7 +390,7 @@ def test_backoff_conns_disconnect():
     conns = []
     for i in range(num_conns):
         conn = _get_conn(r)
-        conn.expected_args = ['SUB test test\n', 'RDY 1\n']
+        conn.expected_args = [b'SUB test test\n', b'RDY 1\n']
         conn.fails = 0
         conns.append(conn)
 
@@ -408,18 +409,18 @@ def test_backoff_conns_disconnect():
                 if not conn:
                     conn = random.choice(conns)
                 else:
-                    conn.expected_args.append('RDY 1\n')
+                    conn.expected_args.append(b'RDY 1\n')
                 continue
             else:
                 c = _get_conn(r)
-                c.expected_args = ['SUB test test\n']
+                c.expected_args = [b'SUB test test\n']
                 c.fails = 0
                 conns.append(c)
 
         msg = _send_message(conn)
 
         if r.backoff_timer.get_interval() == 0:
-            conn.expected_args.append('RDY 1\n')
+            conn.expected_args.append(b'RDY 1\n')
 
         if fail or not conn.fails:
             msg.trigger(event.REQUEUE, message=msg)
@@ -427,16 +428,16 @@ def test_backoff_conns_disconnect():
             conn.fails += 1
 
             for c in conns:
-                c.expected_args.append('RDY 0\n')
-            conn.expected_args.append('REQ 1234 0\n')
+                c.expected_args.append(b'RDY 0\n')
+            conn.expected_args.append(b'REQ 1234 0\n')
         else:
             msg.trigger(event.FINISH, message=msg)
             total_fails -= 1
             conn.fails -= 1
 
             for c in conns:
-                c.expected_args.append('RDY 0\n')
-            conn.expected_args.append('FIN 1234\n')
+                c.expected_args.append(b'RDY 0\n')
+            conn.expected_args.append(b'FIN 1234\n')
 
         assert r.backoff_block is True
         assert r.backoff_timer.get_interval() > 0
@@ -447,7 +448,7 @@ def test_backoff_conns_disconnect():
             conn = timeout_args[1]()
             last_timeout_time = timeout_args[0]
         assert r.backoff_block is False
-        conn.expected_args.append('RDY 1\n')
+        conn.expected_args.append(b'RDY 1\n')
 
         fail = True
         if random.random() < 0.3 and total_fails > 1:
@@ -464,12 +465,12 @@ def test_backoff_conns_disconnect():
 
         if total_fails > 0:
             for c in conns:
-                c.expected_args.append('RDY 0\n')
+                c.expected_args.append(b'RDY 0\n')
         else:
             for c in conns:
-                c.expected_args.append('RDY 1\n')
+                c.expected_args.append(b'RDY 1\n')
 
-        conn.expected_args.append('FIN 1234\n')
+        conn.expected_args.append(b'FIN 1234\n')
 
         timeout_args, timeout_kwargs = mock_ioloop.add_timeout.call_args
         if timeout_args[0] != last_timeout_time:
@@ -477,7 +478,7 @@ def test_backoff_conns_disconnect():
             last_timeout_time = timeout_args[0]
 
         if total_fails > 0:
-            conn.expected_args.append('RDY 1\n')
+            conn.expected_args.append(b'RDY 1\n')
 
     assert r.backoff_block is False
     assert r.backoff_timer.get_interval() == 0

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
-
+from __future__ import print_function
 from __future__ import with_statement
+
 import os
 import sys
 import random
@@ -195,7 +196,7 @@ def test_backoff_requeue_recovery():
     assert r.backoff_block is False
     assert r.backoff_timer.get_interval() == 0
 
-    print conn.stream.write.call_args_list
+    print(conn.stream.write.call_args_list)
 
     expected_args = [
         'SUB test test\n',
@@ -277,7 +278,7 @@ def test_backoff_hard():
     assert r.backoff_timer.get_interval() == 0
 
     for i, call in enumerate(conn.stream.write.call_args_list):
-        print "%d: %s" % (i, call)
+        print("%d: %s" % (i, call))
     assert conn.stream.write.call_args_list == [((arg,),) for arg in expected_args]
 
 
@@ -336,7 +337,7 @@ def test_backoff_many_conns():
             fail = False
 
     while total_fails:
-        print "%r: %d fails (%d total_fails)" % (conn, conn.fails, total_fails)
+        print("%r: %d fails (%d total_fails)" % (conn, conn.fails, total_fails))
 
         if not conn.fails:
             # force an idle connection
@@ -376,7 +377,7 @@ def test_backoff_many_conns():
 
     for c in conns:
         for i, call in enumerate(c.stream.write.call_args_list):
-            print "%d: %s" % (i, call)
+            print("%d: %s" % (i, call))
         assert c.stream.write.call_args_list == [((arg,),) for arg in c.expected_args]
 
 
@@ -453,7 +454,7 @@ def test_backoff_conns_disconnect():
             fail = False
 
     while total_fails:
-        print "%r: %d fails (%d total_fails)" % (conn, conn.fails, total_fails)
+        print("%r: %d fails (%d total_fails)" % (conn, conn.fails, total_fails))
 
         msg = _send_message(conn)
 
@@ -483,5 +484,5 @@ def test_backoff_conns_disconnect():
 
     for c in conns:
         for i, call in enumerate(c.stream.write.call_args_list):
-            print "%d: %s" % (i, call)
+            print("%d: %s" % (i, call))
         assert c.stream.write.call_args_list == [((arg,),) for arg in c.expected_args]

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import struct
 import pytest
 import os
 import sys
@@ -17,6 +16,7 @@ if base_dir not in sys.path:
     sys.path.insert(0, base_dir)
 
 from nsq._compat import to_bytes
+from nsq._compat import struct_pack
 from nsq import protocol
 
 
@@ -27,16 +27,16 @@ def pytest_generate_tests(metafunc):
     identify_body_unicode = to_bytes(json.dumps(identify_dict_unicode))
 
     msgs = [b'asdf', b'ghjk', b'abcd']
-    mpub_body = struct.pack('>l', len(msgs)) + b''.join(struct.pack('>l', len(m)) + m for m in msgs)
+    mpub_body = struct_pack('>l', len(msgs)) + b''.join(struct_pack('>l', len(m)) + m for m in msgs)
     if metafunc.function == test_command:
         for cmd_method, kwargs, result in [
                 (protocol.identify,
                     {'data': identify_dict_ascii},
-                    b'IDENTIFY\n' + struct.pack('>l', len(identify_body_ascii)) +
+                    b'IDENTIFY\n' + struct_pack('>l', len(identify_body_ascii)) +
                     to_bytes(identify_body_ascii)),
                 (protocol.identify,
                     {'data': identify_dict_unicode},
-                    b'IDENTIFY\n' + struct.pack('>l', len(identify_body_unicode)) +
+                    b'IDENTIFY\n' + struct_pack('>l', len(identify_body_unicode)) +
                     to_bytes(identify_body_unicode)),
                 (protocol.subscribe,
                     {'topic': 'test_topic', 'channel': 'test_channel'},
@@ -64,10 +64,10 @@ def pytest_generate_tests(metafunc):
                     b'NOP\n'),
                 (protocol.pub,
                     {'topic': 'test', 'data': msgs[0]},
-                    b'PUB test\n' + struct.pack('>l', len(msgs[0])) + to_bytes(msgs[0])),
+                    b'PUB test\n' + struct_pack('>l', len(msgs[0])) + to_bytes(msgs[0])),
                 (protocol.mpub,
                     {'topic': 'test', 'data': msgs},
-                    b'MPUB test\n' + struct.pack('>l', len(mpub_body)) + to_bytes(mpub_body))
+                    b'MPUB test\n' + struct_pack('>l', len(mpub_body)) + to_bytes(mpub_body))
                 ]:
             metafunc.addcall(funcargs=dict(cmd_method=cmd_method, kwargs=kwargs, result=result))
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import struct
 import pytest
@@ -15,57 +16,58 @@ base_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__
 if base_dir not in sys.path:
     sys.path.insert(0, base_dir)
 
+from nsq._compat import to_bytes
 from nsq import protocol
 
 
 def pytest_generate_tests(metafunc):
     identify_dict_ascii = {'a': 1, 'b': 2}
     identify_dict_unicode = {'c': u'w\xc3\xa5\xe2\x80\xa0'}
-    identify_body_ascii = json.dumps(identify_dict_ascii)
-    identify_body_unicode = json.dumps(identify_dict_unicode)
+    identify_body_ascii = to_bytes(json.dumps(identify_dict_ascii))
+    identify_body_unicode = to_bytes(json.dumps(identify_dict_unicode))
 
-    msgs = ['asdf', 'ghjk', 'abcd']
-    mpub_body = struct.pack('>l', len(msgs)) + ''.join(struct.pack('>l', len(m)) + m for m in msgs)
+    msgs = [b'asdf', b'ghjk', b'abcd']
+    mpub_body = struct.pack('>l', len(msgs)) + b''.join(struct.pack('>l', len(m)) + m for m in msgs)
     if metafunc.function == test_command:
         for cmd_method, kwargs, result in [
                 (protocol.identify,
                     {'data': identify_dict_ascii},
-                    'IDENTIFY\n' + struct.pack('>l', len(identify_body_ascii)) +
-                    identify_body_ascii),
+                    b'IDENTIFY\n' + struct.pack('>l', len(identify_body_ascii)) +
+                    to_bytes(identify_body_ascii)),
                 (protocol.identify,
                     {'data': identify_dict_unicode},
-                    'IDENTIFY\n' + struct.pack('>l', len(identify_body_unicode)) +
-                    identify_body_unicode),
+                    b'IDENTIFY\n' + struct.pack('>l', len(identify_body_unicode)) +
+                    to_bytes(identify_body_unicode)),
                 (protocol.subscribe,
                     {'topic': 'test_topic', 'channel': 'test_channel'},
-                    'SUB test_topic test_channel\n'),
+                    b'SUB test_topic test_channel\n'),
                 (protocol.finish,
                     {'id': 'test'},
-                    'FIN test\n'),
+                    b'FIN test\n'),
                 (protocol.finish,
                     {'id': u'\u2020est \xfcn\xee\xe7\xf8\u2202\xe9'},
-                    'FIN \xe2\x80\xa0est \xc3\xbcn\xc3\xae\xc3\xa7\xc3\xb8\xe2\x88\x82\xc3\xa9\n'),
+                    b'FIN \xe2\x80\xa0est \xc3\xbcn\xc3\xae\xc3\xa7\xc3\xb8\xe2\x88\x82\xc3\xa9\n'),
                 (protocol.requeue,
                     {'id': 'test'},
-                    'REQ test 0\n'),
+                    b'REQ test 0\n'),
                 (protocol.requeue,
                     {'id': 'test', 'time_ms': 60},
-                    'REQ test 60\n'),
+                    b'REQ test 60\n'),
                 (protocol.touch,
                     {'id': 'test'},
-                    'TOUCH test\n'),
+                    b'TOUCH test\n'),
                 (protocol.ready,
                     {'count': 100},
-                    'RDY 100\n'),
+                    b'RDY 100\n'),
                 (protocol.nop,
                     {},
-                    'NOP\n'),
+                    b'NOP\n'),
                 (protocol.pub,
                     {'topic': 'test', 'data': msgs[0]},
-                    'PUB test\n' + struct.pack('>l', len(msgs[0])) + msgs[0]),
+                    b'PUB test\n' + struct.pack('>l', len(msgs[0])) + to_bytes(msgs[0])),
                 (protocol.mpub,
                     {'topic': 'test', 'data': msgs},
-                    'MPUB test\n' + struct.pack('>l', len(mpub_body)) + mpub_body)
+                    b'MPUB test\n' + struct.pack('>l', len(mpub_body)) + to_bytes(mpub_body))
                 ]:
             metafunc.addcall(funcargs=dict(cmd_method=cmd_method, kwargs=kwargs, result=result))
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 
 import os
 import sys
@@ -81,7 +82,7 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         c.on('identify_response', self.stop)
         c.connect()
         response = self.wait()
-        print response
+        print(response)
         assert response['conn'] is c
         assert isinstance(response['data'], dict)
 
@@ -91,7 +92,7 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         c.on('identify_response', self.stop)
         c.connect()
         response = self.wait()
-        print response
+        print(response)
         assert response['conn'] is c
         assert isinstance(response['data'], dict)
         assert response['data']['snappy'] is True
@@ -118,7 +119,7 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         c.on('ready', _on_ready)
         c.connect()
         response = self.wait()
-        print response
+        print(response)
         assert response['conn'] is c
         assert response['data'] == 'OK'
 
@@ -221,7 +222,7 @@ class DeflateReaderIntegrationTest(ReaderIntegrationTest):
         c.on('identify_response', self.stop)
         c.connect()
         response = self.wait()
-        print response
+        print(response)
         assert response['conn'] is c
         assert isinstance(response['data'], dict)
         assert response['data']['deflate'] is True

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os
 import sys
@@ -48,7 +49,7 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         while True:
             try:
                 resp = http.fetch('http://127.0.0.1:4151/ping')
-                if resp.body == 'OK':
+                if resp.body == b'OK':
                     break
                 continue
             except:
@@ -121,7 +122,7 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         response = self.wait()
         print(response)
         assert response['conn'] is c
-        assert response['data'] == 'OK'
+        assert response['data'] == b'OK'
 
     def _send_messages(self, topic, count, body):
         c = AsyncConn('127.0.0.1', 4150, io_loop=self.io_loop)
@@ -137,7 +138,7 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         self.msg_count = 0
 
         topic = 'test_conn_suscribe_%s' % time.time()
-        self._send_messages(topic, 5, 'sup')
+        self._send_messages(topic, 5, b'sup')
 
         c = AsyncConn('127.0.0.1', 4150, io_loop=self.io_loop,
                       **self.identify_options)
@@ -163,10 +164,10 @@ class ReaderIntegrationTest(tornado.testing.AsyncTestCase):
         num_messages = 500
 
         topic = 'test_reader_msgs_%s' % time.time()
-        self._send_messages(topic, num_messages, 'sup')
+        self._send_messages(topic, num_messages, b'sup')
 
         def handler(msg):
-            assert msg.body == 'sup'
+            assert msg.body == b'sup'
             self.msg_count += 1
             if self.msg_count >= num_messages:
                 self.stop()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import struct
 import time
@@ -22,7 +23,7 @@ def mock_response_write(c, frame_type, data):
 def mock_response_write_message(c, timestamp, attempts, id, body):
     timestamp_packed = struct.pack('>q', timestamp)
     attempts_packed = struct.pack('>h', attempts)
-    id = "%016d" % id
+    id = b"%016d" % id
     mock_response_write(
         c, protocol.FRAME_TYPE_MESSAGE, timestamp_packed + attempts_packed + id + body)
 
@@ -34,18 +35,18 @@ def test_sync_authenticate_subscribe():
     c.send(protocol.identify({'short_id': 'test', 'long_id': 'test.example'}))
     c.send(protocol.subscribe('test', 'ch'))
 
-    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, 'OK')
-    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, 'OK')
+    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, b'OK')
+    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, b'OK')
 
     resp = c.read_response()
     unpacked = protocol.unpack_response(resp)
     assert unpacked[0] == protocol.FRAME_TYPE_RESPONSE
-    assert unpacked[1] == 'OK'
+    assert unpacked[1] == b'OK'
 
     resp = c.read_response()
     unpacked = protocol.unpack_response(resp)
     assert unpacked[0] == protocol.FRAME_TYPE_RESPONSE
-    assert unpacked[1] == 'OK'
+    assert unpacked[1] == b'OK'
 
 
 def test_sync_receive_messages():
@@ -55,22 +56,22 @@ def test_sync_receive_messages():
     c.send(protocol.identify({'short_id': 'test', 'long_id': 'test.example'}))
     c.send(protocol.subscribe('test', 'ch'))
 
-    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, 'OK')
-    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, 'OK')
+    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, b'OK')
+    mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, b'OK')
 
     resp = c.read_response()
     unpacked = protocol.unpack_response(resp)
     assert unpacked[0] == protocol.FRAME_TYPE_RESPONSE
-    assert unpacked[1] == 'OK'
+    assert unpacked[1] == b'OK'
 
     resp = c.read_response()
     unpacked = protocol.unpack_response(resp)
     assert unpacked[0] == protocol.FRAME_TYPE_RESPONSE
-    assert unpacked[1] == 'OK'
+    assert unpacked[1] == b'OK'
 
     for i in range(10):
         c.send(protocol.ready(1))
-        body = '{"data": {"test_key": %d}}' % i
+        body = b'{"data": {"test_key": %d}}' % i
         ts = int(time.time() * 1000 * 1000)
         mock_response_write_message(c, ts, 0, i, body)
         resp = c.read_response()
@@ -78,6 +79,6 @@ def test_sync_receive_messages():
         assert unpacked[0] == protocol.FRAME_TYPE_MESSAGE
         msg = protocol.decode_message(unpacked[1])
         assert msg.timestamp == ts
-        assert msg.id == "%016d" % i
+        assert msg.id == b"%016d" % i
         assert msg.attempts == 0
         assert msg.body == body

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import struct
 import time
 
 from . import mock_socket
+
+from nsq._compat import struct_pack
 from nsq import protocol, sync
 sync.socket = mock_socket
 
@@ -15,14 +16,14 @@ def mock_write(c, data):
 
 def mock_response_write(c, frame_type, data):
     body_size = 4 + len(data)
-    body_size_packed = struct.pack('>l', body_size)
-    frame_type_packed = struct.pack('>l', frame_type)
+    body_size_packed = struct_pack('>l', body_size)
+    frame_type_packed = struct_pack('>l', frame_type)
     mock_write(c, body_size_packed + frame_type_packed + data)
 
 
 def mock_response_write_message(c, timestamp, attempts, id, body):
-    timestamp_packed = struct.pack('>q', timestamp)
-    attempts_packed = struct.pack('>h', attempts)
+    timestamp_packed = struct_pack('>q', timestamp)
+    attempts_packed = struct_pack('>h', attempts)
     id = b"%016d" % id
     mock_response_write(
         c, protocol.FRAME_TYPE_MESSAGE, timestamp_packed + attempts_packed + id + body)


### PR DESCRIPTION
I'm super keen to get a version of `pynsq` working on Python 3. There appear to have been a couple of valiant attempts to get this working in the past, including #88, #102, and most recently #127. None of these have been merged, so here's another attempt to get this working, which tries to achieve the following:

- Each set of changes has been made in its own commit, with an explanation of what the change is and why it's needed for Python 3 compatibility.
- I've made sure that the concerns previously raised [[1](https://github.com/nsqio/pynsq/pull/102#discussion_r20363807), [2](https://github.com/nsqio/pynsq/pull/127#discussion_r32329639)] around ensuring that message bodies are bytestrings, not text, have been addressed. (*N.B.* The code previously didn't check individual bodies in `mpub` until they were sent as one fully-encoded command. I've [added an assertion](https://github.com/nsqio/pynsq/pull/150/files#diff-7be937e744241e6e60c4fb927cd1020aR130) to check this earlier -- let me know if that's problematic.)
- Wherever possible, I've added `from __future__ import unicode_literals` so that the distinction between bytestring literals and unicode literals works the same on Python 2.x and 3.x -- hopefully this makes it clearer where we're translating between the two.

The test suite is currently passing, but I want to emphasise two caveats at this point:

1. I *have not yet tested this* properly -- i.e. hooking it up to NSQ and actually trying to send serious amounts of data through it. I wouldn't want to suggest you merge it until I (or someone, at least) has had a chance to do that.

2. I'm not currently clear on whether [this patch](https://github.com/ijl/pynsq/commit/ff25c744a28e66c046ac52c299d6954c2e9f83af) is still necessary. Perhaps I'll find that out when I try and use this in anger.

