### PR TITLE
reader: don't use Decimal class to calculate backoff

### DIFF
--- a/nsq/backoff_timer.py
+++ b/nsq/backoff_timer.py
@@ -3,44 +3,37 @@ from __future__ import absolute_import
 from decimal import Decimal
 
 
-def _Decimal(v):
-    if not isinstance(v, Decimal):
-        return Decimal(str(v))
-    return v
-
-
 class BackoffTimer(object):
     """
     This is a timer that is smart about backing off exponentially when there are problems
+    
+    Internally, the intervals are tracked as integers so that calculation
+    is less expensive.
     """
     def __init__(self, min_interval, max_interval, ratio=.25, short_length=10, long_length=250):
         assert isinstance(min_interval, (int, float, Decimal))
         assert isinstance(max_interval, (int, float, Decimal))
 
-        self.min_interval = _Decimal(min_interval)
-        self.max_interval = _Decimal(max_interval)
+        self.min_interval = int(float(min_interval) * 1000000)
+        self.max_interval = int(float(max_interval) * 1000000)
 
-        self.max_short_timer = (self.max_interval - self.min_interval) * _Decimal(ratio)
-        self.max_long_timer = (self.max_interval - self.min_interval) * (1 - _Decimal(ratio))
-        self.short_unit = self.max_short_timer / _Decimal(short_length)
-        self.long_unit = self.max_long_timer / _Decimal(long_length)
+        self.max_short_timer = int((self.max_interval - self.min_interval) * float(ratio))
+        self.max_long_timer = int((self.max_interval - self.min_interval) * (1 - float(ratio)))
+        self.short_unit = int(self.max_short_timer / float(short_length))
+        self.long_unit = int(self.max_long_timer / float(long_length))
 
-        self.short_interval = Decimal(0)
-        self.long_interval = Decimal(0)
+        self.short_interval = 0
+        self.long_interval = 0
 
     def success(self):
         """Update the timer to reflect a successfull call"""
-        self.short_interval -= self.short_unit
-        self.long_interval -= self.long_unit
-        self.short_interval = max(self.short_interval, Decimal(0))
-        self.long_interval = max(self.long_interval, Decimal(0))
+        self.short_interval = max(self.short_interval - self.short_unit, 0)
+        self.long_interval = max(self.long_interval - self.long_unit, 0)
 
     def failure(self):
         """Update the timer to reflect a failed call"""
-        self.short_interval += self.short_unit
-        self.long_interval += self.long_unit
-        self.short_interval = min(self.short_interval, self.max_short_timer)
-        self.long_interval = min(self.long_interval, self.max_long_timer)
+        self.short_interval = min(self.short_interval + self.short_unit, self.max_short_timer)
+        self.long_interval = min(self.long_interval + self.long_unit, self.max_long_timer)
 
     def get_interval(self):
-        return float(self.min_interval + self.short_interval + self.long_interval)
+        return (self.min_interval + self.short_interval + self.long_interval) / 1000000.0

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -51,9 +51,9 @@ def test_backoff_timer():
     timer.failure()
     interval = '%0.2f' % timer.get_interval()
     assert interval == '3.19'
-    assert timer.min_interval == Decimal('.1')
-    assert timer.short_interval == Decimal('2.9975')
-    assert timer.long_interval == Decimal('0.089925')
+    assert timer.min_interval == 100000 #Decimal('.1')
+    assert timer.short_interval == 2997500 # Decimal('2.9975')
+    assert timer.long_interval == 89925 #Decimal('0.089925')
 
     timer.failure()
     interval = '%0.2f' % timer.get_interval()


### PR DESCRIPTION
It's not immediately clear why the Decimal class is being used here, when it seems like pure floats are just as good. 

- Profiling indicates lots of time spent here, reduced 50000 messages
  from 23s to 18s (not raw NSQ timing, with custom layering on top)

Haven't ran the tests yet, going to let Travis do that for me :)