### PR TITLE
reader: optimize BackoffTimer using float

### DIFF
--- a/nsq/backoff_timer.py
+++ b/nsq/backoff_timer.py
@@ -27,13 +27,17 @@ class BackoffTimer(object):
 
         self.short_interval = Decimal(0)
         self.long_interval = Decimal(0)
+        self.update_interval()
 
     def success(self):
         """Update the timer to reflect a successfull call"""
+        if self.interval == 0.0:
+            return
         self.short_interval -= self.short_unit
         self.long_interval -= self.long_unit
         self.short_interval = max(self.short_interval, Decimal(0))
         self.long_interval = max(self.long_interval, Decimal(0))
+        self.update_interval()
 
     def failure(self):
         """Update the timer to reflect a failed call"""
@@ -41,6 +45,10 @@ class BackoffTimer(object):
         self.long_interval += self.long_unit
         self.short_interval = min(self.short_interval, self.max_short_timer)
         self.long_interval = min(self.long_interval, self.max_long_timer)
+        self.update_interval()
+
+    def update_interval(self):
+        self.interval = float(self.min_interval + self.short_interval + self.long_interval)
 
     def get_interval(self):
-        return float(self.min_interval + self.short_interval + self.long_interval)
+        return self.interval


### PR DESCRIPTION
my version of #155 

performance tested with @virtuald's [rawperf.py](https://gist.github.com/virtuald/d7416e06d0d348af30aa1425fb67a5b6) on a plugged-in 2013 macbook pro retina 13"

  * master: about 16s
  * optim_backofftimer: about 12s

Maybe a refactor - to not call these methods so much - is what the library really needs, but this was a fun easy exercise :grin: