### PR TITLE
Reuse struct objects

### DIFF
--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -28,11 +28,8 @@ if not PY2:
             return x.encode(charset, errors)
         raise TypeError('expected bytes or a string, not %r' % type(x))
 
-    def struct_pack(fmt, *values):
-        return struct.pack(fmt, *values)
-
-    def struct_unpack(fmt, string):
-        return struct.unpack(fmt, string)
+    def _create_struct(fmt):
+        return struct.Struct(fmt)
 
 else:
     bytes_types = (bytes, bytearray, buffer)
@@ -53,11 +50,12 @@ else:
     # Python 2.6 has the rather unfortunate problem of raising a TypeError if
     # you pass a unicode object as the `fmt` parameter. This shim can be
     # removed when support for Python earlier than 2.7 is dropped.
-    def struct_pack(fmt, *values):
-        return struct.pack(str(fmt), *values)
+    def _create_struct(fmt):
+        return struct.Struct(str(fmt))
 
-    def struct_unpack(fmt, string):
-        return struct.unpack(str(fmt), string)
+struct_l = _create_struct('>l')
+struct_q = _create_struct('>q')
+struct_h = _create_struct('>h')
 
 try:
     from urllib import parse as urlparse

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -6,7 +6,7 @@ import socket
 import logging
 
 from ._compat import string_types
-from ._compat import struct_unpack
+from ._compat import struct_l
 from .version import __version__
 
 try:
@@ -261,7 +261,7 @@ class AsyncConn(event.EventedMixin):
 
     def _read_size(self, data):
         try:
-            size = struct_unpack('>l', data)[0]
+            size = struct_l.unpack(data)[0]
         except Exception:
             self.close()
             self.trigger(

--- a/nsq/protocol.py
+++ b/nsq/protocol.py
@@ -9,7 +9,7 @@ except ImportError:
 
 from ._compat import bytes_types
 from ._compat import to_bytes
-from ._compat import struct_pack, struct_unpack
+from ._compat import struct_h, struct_l, struct_q
 from .message import Message
 
 MAGIC_V2 = b'  V2'
@@ -57,13 +57,13 @@ class IntegrityError(Error):
 
 
 def unpack_response(data):
-    frame = struct_unpack('>l', data[:4])[0]
+    frame = struct_l.unpack(data[:4])[0]
     return frame, data[4:]
 
 
 def decode_message(data):
-    timestamp = struct_unpack('>q', data[:8])[0]
-    attempts = struct_unpack('>h', data[8:10])[0]
+    timestamp = struct_q.unpack(data[:8])[0]
+    attempts = struct_h.unpack(data[8:10])[0]
     id = data[10:26]
     body = data[26:]
     return Message(id, body, timestamp, attempts)
@@ -75,7 +75,7 @@ def _command(cmd, body, *params):
     if body:
         assert isinstance(body, bytes_types), 'body must be a bytestring'
         body_bytes = to_bytes(body)  # raises if not convertible to bytes
-        body_data = struct_pack('>l', len(body)) + body_bytes
+        body_data = struct_l.pack(len(body)) + body_bytes
     if len(params):
         params = [to_bytes(p) for p in params]
         params_data = b' ' + b' '.join(params)
@@ -125,10 +125,10 @@ def pub(topic, data):
 
 def mpub(topic, data):
     assert isinstance(data, (set, list))
-    body = struct_pack('>l', len(data))
+    body = struct_l.pack(len(data))
     for m in data:
         assert isinstance(m, bytes_types), 'message bodies must be bytestrings'
-        body += struct_pack('>l', len(m)) + to_bytes(m)
+        body += struct_l.pack(len(m)) + to_bytes(m)
     return _command(MPUB, body, topic)
 
 

--- a/nsq/sync.py
+++ b/nsq/sync.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import socket
 
 from nsq._compat import string_types
-from nsq._compat import struct_unpack
+from nsq._compat import struct_l
 from nsq import protocol
 
 
@@ -35,7 +35,7 @@ class SyncConn(object):
         return data
 
     def read_response(self):
-        size = struct_unpack('>l', self._readn(4))[0]
+        size = struct_l.unpack(self._readn(4))[0]
         return self._readn(size)
 
     def send(self, data):

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -12,7 +12,7 @@ base_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__
 if base_dir not in sys.path:
     sys.path.insert(0, base_dir)
 
-from nsq._compat import struct_pack
+from nsq._compat import struct_l
 from nsq.async import AsyncConn
 from nsq import protocol
 
@@ -80,7 +80,7 @@ def test_start_read():
 def test_read_size():
     conn = _get_test_conn()
     body_size = 6
-    body_size_packed = struct_pack('>l', body_size)
+    body_size_packed = struct_l.pack(body_size)
     conn._read_size(body_size_packed)
     conn.stream.read_bytes.assert_called_once_with(body_size, conn._read_body)
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -16,7 +16,7 @@ if base_dir not in sys.path:
     sys.path.insert(0, base_dir)
 
 from nsq._compat import to_bytes
-from nsq._compat import struct_pack
+from nsq._compat import struct_l
 from nsq import protocol
 
 
@@ -27,16 +27,16 @@ def pytest_generate_tests(metafunc):
     identify_body_unicode = to_bytes(json.dumps(identify_dict_unicode))
 
     msgs = [b'asdf', b'ghjk', b'abcd']
-    mpub_body = struct_pack('>l', len(msgs)) + b''.join(struct_pack('>l', len(m)) + m for m in msgs)
+    mpub_body = struct_l.pack(len(msgs)) + b''.join(struct_l.pack(len(m)) + m for m in msgs)
     if metafunc.function == test_command:
         for cmd_method, kwargs, result in [
                 (protocol.identify,
                     {'data': identify_dict_ascii},
-                    b'IDENTIFY\n' + struct_pack('>l', len(identify_body_ascii)) +
+                    b'IDENTIFY\n' + struct_l.pack(len(identify_body_ascii)) +
                     to_bytes(identify_body_ascii)),
                 (protocol.identify,
                     {'data': identify_dict_unicode},
-                    b'IDENTIFY\n' + struct_pack('>l', len(identify_body_unicode)) +
+                    b'IDENTIFY\n' + struct_l.pack(len(identify_body_unicode)) +
                     to_bytes(identify_body_unicode)),
                 (protocol.subscribe,
                     {'topic': 'test_topic', 'channel': 'test_channel'},
@@ -64,10 +64,10 @@ def pytest_generate_tests(metafunc):
                     b'NOP\n'),
                 (protocol.pub,
                     {'topic': 'test', 'data': msgs[0]},
-                    b'PUB test\n' + struct_pack('>l', len(msgs[0])) + to_bytes(msgs[0])),
+                    b'PUB test\n' + struct_l.pack(len(msgs[0])) + to_bytes(msgs[0])),
                 (protocol.mpub,
                     {'topic': 'test', 'data': msgs},
-                    b'MPUB test\n' + struct_pack('>l', len(mpub_body)) + to_bytes(mpub_body))
+                    b'MPUB test\n' + struct_l.pack(len(mpub_body)) + to_bytes(mpub_body))
                 ]:
             metafunc.addcall(funcargs=dict(cmd_method=cmd_method, kwargs=kwargs, result=result))
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,7 +5,7 @@ import time
 
 from . import mock_socket
 
-from nsq._compat import struct_pack
+from nsq._compat import struct_h, struct_l, struct_q
 from nsq import protocol, sync
 sync.socket = mock_socket
 
@@ -16,14 +16,14 @@ def mock_write(c, data):
 
 def mock_response_write(c, frame_type, data):
     body_size = 4 + len(data)
-    body_size_packed = struct_pack('>l', body_size)
-    frame_type_packed = struct_pack('>l', frame_type)
+    body_size_packed = struct_l.pack(body_size)
+    frame_type_packed = struct_l.pack(frame_type)
     mock_write(c, body_size_packed + frame_type_packed + data)
 
 
 def mock_response_write_message(c, timestamp, attempts, id, body):
-    timestamp_packed = struct_pack('>q', timestamp)
-    attempts_packed = struct_pack('>h', attempts)
+    timestamp_packed = struct_q.pack(timestamp)
+    attempts_packed = struct_h.pack(attempts)
     id = b"%016d" % id
     mock_response_write(
         c, protocol.FRAME_TYPE_MESSAGE, timestamp_packed + attempts_packed + id + body)


### PR DESCRIPTION
From the python docs: 

> Creating a Struct object once and calling its methods is more efficient than calling the struct functions with the same format since the format string only needs to be compiled once.