### PR TITLE
Minor performance tweaks

### DIFF
--- a/nsq/async.py
+++ b/nsq/async.py
@@ -277,7 +277,7 @@ class AsyncConn(event.EventedMixin):
             self.trigger(event.DATA, conn=self, data=data)
         except Exception:
             logger.exception('uncaught exception in data event')
-        self.io_loop.add_callback(self._start_read)
+        self._start_read()
 
     def send(self, data):
         self.stream.write(data)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -100,17 +100,15 @@ def test_read_body():
     on_data = create_autospec(f)
     conn.on('data', on_data)
 
-    mock_ioloop_addcb = create_autospec(f)
-    mock_io_loop.add_callback = mock_ioloop_addcb
     data = 'NSQ'
     conn._read_body(data)
     on_data.assert_called_once_with(conn=conn, data=data)
-    mock_ioloop_addcb.assert_called_once_with(conn._start_read)
+    conn.stream.read_bytes.assert_called_once_with(4, conn._read_size)
 
     # now test functionality when the data_callback fails
     on_data.reset_mock()
-    mock_ioloop_addcb.reset_mock()
+    conn.stream.read_bytes.reset_mock()
     on_data.return_value = Exception("Boom.")
     conn._read_body(data)
-    # verify that we still added callback for the next start_read
-    mock_ioloop_addcb.assert_called_once_with(conn._start_read)
+    # verify that the next _start_read was called
+    conn.stream.read_bytes.assert_called_once_with(4, conn._read_size)


### PR DESCRIPTION
The first one is pretty self-explanatory (maybe needs another PR?) -- only call `time.time()` once, the extra function overhead (despite how small it is) isn't necessary.

The second one we can debate, in the reader it now immediately calls _start_read() instead of going through the IOLoop to call it. This results in a ~1s improvement in my [rawperf script](https://gist.github.com/virtuald/d7416e06d0d348af30aa1425fb67a5b6). I think I understand why it was done this way originally -- presumably don't want to starve the IOLoop if messages just happen to come in at the perfect rate where the socket buffer can keep feeding messages... since the read functions will call each other continuously in a loop without yielding to the IOLoop.

But... I wonder if that can actually happen?

If it can happen... then perhaps it should only use add_callback every once in awhile, or if it detects a cycle... or some other probably terrible thing? At the very least, should add a note as to why the code is using add_callback here.