### PR TITLE
reader: python3 type error in nsqlookupd response parsing

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -594,7 +594,7 @@ class Reader(Client):
             return
 
         try:
-            lookup_data = json.loads(response.body)
+            lookup_data = json.loads(response.body.decode("utf8"))
         except ValueError:
             logger.warning('[%s] lookupd %s failed to parse JSON: %r',
                            self.name, lookupd_url, response.body)


### PR DESCRIPTION
Tornado's HTTPResponse body is of type bytes in Python3 and json.loads cannot be performed. 

Execution of:
```
import tornado.ioloop
import nsq


def handler(message):
    print(message)
    return True

r = nsq.Reader(message_handler=handler,
               lookupd_http_addresses=['nsqlookupd:4161'],
               topic='test', channel='test', lookupd_poll_interval=15)
nsq.run()

tornado.ioloop.IOLoop.current().start()
```
Results with:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/tornado/ioloop.py", line 604, in _run_callback
    ret = callback()
  File "/usr/local/lib/python3.5/site-packages/tornado/stack_context.py", line 275, in null_wrapper
    return fn(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/nsq/reader.py", line 597, in _finish_query_lookupd
    lookup_data = json.loads(response.body)
  File "/usr/local/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

Clarification of what is a type of HTTPResponse.body:
https://github.com/tornadoweb/tornado/commit/d1cab4aff57e000d351d168210a71377c8111726