### PR TITLE
fix protocol.SendError in python 3.4

### DIFF
--- a/nsq/protocol.py
+++ b/nsq/protocol.py
@@ -79,7 +79,7 @@ def _command(cmd, body, *params):
     if len(params):
         params = [to_bytes(p) for p in params]
         params_data = b' ' + b' '.join(params)
-    return b'%s%s%s%s' % (cmd, params_data, NL, body_data)
+    return b''.join((cmd, params_data, NL, body_data))
 
 
 def subscribe(topic, channel):


### PR DESCRIPTION
% formatting is availble since python 3.5

see: http://legacy.python.org/dev/peps/pep-0461/