### PR TITLE
1.0 compatible lookupd queries

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -582,6 +582,7 @@ class Reader(Client):
 
         req = tornado.httpclient.HTTPRequest(
             lookupd_url, method='GET',
+            header={"Accept":"application/vnd.nsq; version=1.0"},
             connect_timeout=self.lookupd_connect_timeout,
             request_timeout=self.lookupd_request_timeout)
         callback = functools.partial(self._finish_query_lookupd, lookupd_url=lookupd_url)
@@ -600,12 +601,7 @@ class Reader(Client):
                            self.name, lookupd_url, response.body)
             return
 
-        if lookup_data['status_code'] != 200:
-            logger.warning('[%s] lookupd %s responded with %d',
-                           self.name, lookupd_url, lookup_data['status_code'])
-            return
-
-        for producer in lookup_data['data']['producers']:
+        for producer in lookup_data['producers']:
             # TODO: this can be dropped for 1.0
             address = producer.get('broadcast_address', producer.get('address'))
             assert address


### PR DESCRIPTION
pynsq was not yet making 1.0 compatible queries to lookupd, so this code breaks due to the deprication of the old format in nsqio/nsq#367. This updates to pass the right header to make forwards compatible queries.