### PR TITLE
IDENTIFY: send 1.0 compatible client_id and hostname fields

### DIFF
--- a/nsq/async.py
+++ b/nsq/async.py
@@ -352,8 +352,10 @@ class AsyncConn(event.EventedMixin):
 
     def _on_connect(self, **kwargs):
         identify_data = {
-            'short_id': self.short_hostname,
-            'long_id': self.hostname,
+            'short_id': self.short_hostname, # TODO remove when deprecating pre 1.0 support
+            'long_id': self.hostname, # TODO remove when deprecating pre 1.0 support
+            'client_id': self.short_hostname,
+            'hostname': self.hostname,
             'heartbeat_interval': self.heartbeat_interval,
             'feature_negotiation': True,
             'tls_v1': self.tls_v1,

--- a/nsq/version.py
+++ b/nsq/version.py
@@ -1,2 +1,2 @@
 # also update in setup.py
-__version__ = '0.7.1'
+__version__ = '0.8-alpha'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class PyTest(TestCommand):
 
 
 # also update in nsq/version.py
-version = '0.7.1'
+version = '0.8-alpha'
 
 
 setup(
@@ -39,7 +39,7 @@ setup(
                    'python-snappy', 'tornado'],
     cmdclass={'test': PyTest},
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 6 - Mature',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.6',

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -33,7 +33,7 @@ def test_sync_authenticate_subscribe():
     c = sync.SyncConn()
     c.connect("127.0.0.1", 4150)
 
-    c.send(protocol.identify({'short_id': 'test', 'long_id': 'test.example'}))
+    c.send(protocol.identify({'short_id': 'test', 'long_id': 'test.example', 'client_id': 'test', 'hostname':'test.example'}))
     c.send(protocol.subscribe('test', 'ch'))
 
     mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, b'OK')
@@ -54,7 +54,7 @@ def test_sync_receive_messages():
     c = sync.SyncConn()
     c.connect("127.0.0.1", 4150)
 
-    c.send(protocol.identify({'short_id': 'test', 'long_id': 'test.example'}))
+    c.send(protocol.identify({'short_id': 'test', 'long_id': 'test.example', 'client_id': 'test', 'hostname':'test.example'}))
     c.send(protocol.subscribe('test', 'ch'))
 
     mock_response_write(c, protocol.FRAME_TYPE_RESPONSE, b'OK')


### PR DESCRIPTION
This adds support for new IDENTIFY fields as support for the old fields was removed from nsqd in nsqio/nsq#367