### PR TITLE
Use TCP_NODELAY for improved latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist
 pynsq.egg-info
 build
 docs/_build
+.cache
+.eggs
+*.dat
+*.tmp

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -225,6 +225,7 @@ class AsyncConn(event.EventedMixin):
 
         self.stream = tornado.iostream.IOStream(self.socket, io_loop=self.io_loop)
         self.stream.set_close_callback(self._socket_close)
+        self.stream.set_nodelay(True)
 
         self.state = CONNECTING
         self.on(event.CONNECT, self._on_connect)


### PR DESCRIPTION
According to the NSQ protocol, consumers have to send `FIN`s for every
message they receive, which makes them extremely slow with low `max_in_flight`
values due to TCP buffering.

Adding TCP_NODELAY option on `async.AsyncConn`'s sockets makes `nsq.Reader`
substantially faster. My tests show increase from ~50 to ~4.5K messages per
second on localhost with `max_in_flight = 1`.

----

NODELAY will be enabled by default. It may be disabled by passing `nodelay=False` to `Reader`/`Writer` ctor's kwargs.