### PR TITLE
reader: make sure RDY is updated when connection count changes

### DIFF
--- a/tests/reader_unit_test_helpers.py
+++ b/tests/reader_unit_test_helpers.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import with_statement
+
+from mock import patch, create_autospec
+from tornado.ioloop import IOLoop
+
+import nsq
+from nsq import event
+
+_conn_port = 4150
+
+
+def get_reader(io_loop=None, max_in_flight=5):
+    return nsq.Reader("test", "test",
+                      message_handler=_message_handler,
+                      lookupd_http_addresses=["http://test.local:4161"],
+                      max_in_flight=max_in_flight,
+                      io_loop=io_loop)
+
+
+def get_ioloop():
+    ioloop = create_autospec(IOLoop)
+    ioloop.time.return_value = 0
+    return ioloop
+
+
+def get_conn(reader):
+    global _conn_port
+    with patch('nsq.async.tornado.iostream.IOStream', autospec=True):
+        conn = reader.connect_to_nsqd('localhost', _conn_port)
+    _conn_port += 1
+    conn.trigger(event.READY, conn=conn)
+    return conn
+
+
+def send_message(conn):
+    msg = _get_message(conn)
+    conn.in_flight += 1
+    conn.trigger(event.MESSAGE, conn=conn, message=msg)
+    return msg
+
+
+def _get_message(conn):
+    msg = nsq.Message("1234", "{}", 1234, 0)
+    msg.on('finish', conn._on_message_finish)
+    msg.on('requeue', conn._on_message_requeue)
+    return msg
+
+
+def _message_handler(msg):
+    msg.enable_async()

--- a/tests/test_rdy.py
+++ b/tests/test_rdy.py
@@ -1,0 +1,27 @@
+from .reader_unit_test_helpers import (
+    get_reader,
+    get_ioloop,
+    get_conn,
+    send_message
+)
+
+
+def test_initial_probe_then_full_throttle():
+    mock_ioloop = get_ioloop()
+    r = get_reader(mock_ioloop)
+    conn = get_conn(r)
+    assert conn.rdy == 1
+    send_message(conn)
+    assert conn.rdy == r._connection_max_in_flight()
+
+
+def test_new_conn_throttles_down_existing_conns():
+    mock_ioloop = get_ioloop()
+    r = get_reader(mock_ioloop)
+    conn1 = get_conn(r)
+    send_message(conn1)
+    assert conn1.rdy == r._connection_max_in_flight()
+
+    conn2 = get_conn(r)
+    assert conn2.rdy == 1
+    assert conn1.rdy == r._connection_max_in_flight()


### PR DESCRIPTION
Fixes #182.

Previously, a connection's `rdy` attribute was decremented on message receipt; when it [dipped low enough](https://github.com/nsqio/pynsq/blob/07a75bd5e99ade9d1f6a13593d5bfa17e67c17f4/nsq/reader.py#L361) the connection would send a new `RDY` count of `_connection_max_in_flight()`.  One consequence of this was that, when `_connection_max_in_flight()` changed (because either the connection count or the reader's `max_in_flight` attribute changed), each connection would eventually update to the new value.

The reader's `total_rdy` attribute was also decremented on message receipt.  This guaranteed (under the assumption that some connection was receiving messages), that `total_rdy` would drop below `max_in_flight`, freeing up space for a new connection to send an initial `RDY` count of 1.

Now that these client-side attributes aren't updated with each message received, these two cases need to be catered for explicitly.
