### PR TITLE
Fix converting zero delay to time_ms in Message.requeue()

### DIFF
--- a/nsq/message.py
+++ b/nsq/message.py
@@ -104,7 +104,7 @@ class Message(event.EventedMixin):
         # convert delay to time_ms for fixing
         # https://github.com/nsqio/pynsq/issues/71 and maintaining
         # backward compatibility
-        if 'delay' in kwargs and isinstance(kwargs['delay'], int) and kwargs['delay'] > 0:
+        if 'delay' in kwargs and isinstance(kwargs['delay'], int) and kwargs['delay'] >= 0:
             kwargs['time_ms'] = kwargs['delay'] * 1000
 
         assert not self._has_responded


### PR DESCRIPTION
Before this fix zero delay was not correctly converted and time_ms took its default value -1.