### PR TITLE
PeriodicCallback: remove io_loop argument for tornado v5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
   - python: "2.7"
     env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+  - python: "2.7"
+    env: TORNADO_VERSION=5.0.2 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
 
   - python: "3.4"
     env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
@@ -36,6 +38,11 @@ matrix:
     env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
     dist: xenial
     sudo: true
+  - python: "3.7"
+    env: TORNADO_VERSION=5.0.2 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+    dist: xenial
+    sudo: true
+
 
 script:
   - ./travis_test.sh

--- a/nsq/client.py
+++ b/nsq/client.py
@@ -15,8 +15,7 @@ class Client(object):
             self.io_loop = tornado.ioloop.IOLoop.instance()
 
         tornado.ioloop.PeriodicCallback(self._check_last_recv_timestamps,
-                                        60 * 1000,
-                                        io_loop=self.io_loop).start()
+                                        60 * 1000).start()
 
     def _on_connection_identify(self, conn, data, **kwargs):
         logger.info('[%s:%s] IDENTIFY sent %r' % (conn.id, self.name, data))

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -237,7 +237,6 @@ class Reader(Client):
         self.redist_periodic = PeriodicCallback(
             self._redistribute_rdy_state,
             5 * 1000,
-            io_loop=self.io_loop,
         )
         self.redist_periodic.start()
 
@@ -249,7 +248,6 @@ class Reader(Client):
         self.query_periodic = PeriodicCallback(
             self.query_lookupd,
             self.lookupd_poll_interval * 1000,
-            io_loop=self.io_loop,
         )
 
         # randomize the time we start this poll loop so that all

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         version
     ),
     packages=['nsq'],
-    install_requires=['tornado<5.0'],
+    install_requires=['tornado'],
     include_package_data=True,
     zip_safe=False,
     tests_require=['pytest<4.0', 'mock', 'python-snappy', 'certifi'],


### PR DESCRIPTION
This removes the io_loop argument from `PeriodicCallback` for tornado v5 forwards compatibility.

WIP: This should ideally get tested against tornadov5 but i'm not sure an easy way to do that since it's not released yet. Also i'm not sure this is the complete set of changes needed yet.

```
Traceback (most recent call last):
  File "queuereader_events.py", line 32, in <module>
    only_include_hosts=settings.get('nsqd_silod_on_staging'),
  File "/.../local/lib/python2.7/site-packages/libbitly/NSQReader.py", line 77, in __init__
    super(Reader, self).__init__(*args, **kwargs)
  File "/.../local/lib/python2.7/site-packages/nsq/reader.py", line 159, in __init__
    super(Reader, self).__init__(**kwargs)
  File "/.../local/lib/python2.7/site-packages/nsq/client.py", line 19, in __init__
    io_loop=self.io_loop).start()
TypeError: __init__() got an unexpected keyword argument 'io_loop'
```