### PR TITLE
Deprecation warnings

### DIFF
--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -59,7 +59,8 @@ struct_h = _create_struct('>h')
 
 try:
     from urllib import parse as urlparse
-    from urllib.parse import urlencode
+    from urllib.parse import urlencode, parse_qs
 except ImportError:
     import urlparse
     from urllib import urlencode
+    from cgi import parse_qs

--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -64,3 +64,8 @@ except ImportError:
     import urlparse
     from urllib import urlencode
     from cgi import parse_qs
+
+try:
+    from inspect import getargspec as signature
+except ImportError:
+    from inspect import signature

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -6,7 +6,6 @@ import time
 import functools
 import random
 import warnings
-import inspect
 
 try:
     import simplejson as json
@@ -24,6 +23,7 @@ from ._compat import to_bytes
 from ._compat import urlencode
 from ._compat import urlparse
 from ._compat import parse_qs
+from ._compat import signature
 from .backoff_timer import BackoffTimer
 from .client import Client
 from . import protocol
@@ -208,7 +208,7 @@ class Reader(Client):
         self.random_rdy_ts = time.time()
 
         # Verify keyword arguments
-        valid_args = inspect.getargspec(async.AsyncConn.__init__)[0]
+        valid_args = signature(async.AsyncConn.__init__)[0]
         diff = set(kwargs) - set(valid_args)
         assert len(diff) == 0, 'Invalid keyword argument(s): %s' % list(diff)
 

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -5,7 +5,6 @@ import logging
 import time
 import functools
 import random
-import cgi
 import warnings
 import inspect
 
@@ -24,6 +23,7 @@ from ._compat import string_types
 from ._compat import to_bytes
 from ._compat import urlencode
 from ._compat import urlparse
+from ._compat import parse_qs
 from .backoff_timer import BackoffTimer
 from .client import Client
 from . import protocol
@@ -570,7 +570,7 @@ class Reader(Client):
         if not path or path == "/":
             path = "/lookup"
 
-        params = cgi.parse_qs(query)
+        params = parse_qs(query)
         params['topic'] = self.topic
         query = urlencode(_utf8_params(params), doseq=1)
         lookupd_url = urlparse.urlunsplit((scheme, netloc, path, query, fragment))

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -5,9 +5,9 @@ import logging
 import time
 import functools
 import random
-import inspect
 
 from ._compat import string_types
+from ._compat import signature
 from .client import Client
 from nsq import protocol
 from . import async
@@ -96,7 +96,7 @@ class Writer(Client):
         self.conns = {}
 
         # Verify keyword arguments
-        valid_args = inspect.getargspec(async.AsyncConn.__init__)[0]
+        valid_args = signature(async.AsyncConn.__init__)[0]
         diff = set(kwargs) - set(valid_args)
         assert len(diff) == 0, 'Invalid keyword argument(s): %s' % list(diff)
 


### PR DESCRIPTION
Both `cgi.parse_qs` and `inspect.getargspec` will be deprecated. This pull will replace these with `urllib.parse.parse_qs` and `inspect.signature` respectively if available.