### PR TITLE
consumer: snappy/deflate broken in tornado 4.5

### DIFF
--- a/nsq/deflate_socket.py
+++ b/nsq/deflate_socket.py
@@ -39,6 +39,9 @@ class DeflateSocket(object):
         return uncompressed
 
     def send(self, data):
-        chunk = self._compressor.compress(data)
+        if isinstance(data, memoryview):
+            chunk = self._compressor.compress(str(data))
+        else:
+            chunk = self._compressor.compress(data)
         self._socket.send(chunk + self._compressor.flush(zlib.Z_SYNC_FLUSH))
         return len(data)

--- a/nsq/deflate_socket.py
+++ b/nsq/deflate_socket.py
@@ -40,7 +40,7 @@ class DeflateSocket(object):
 
     def send(self, data):
         if isinstance(data, memoryview):
-            chunk = self._compressor.compress(str(data))
+            chunk = self._compressor.compress(data.tobytes())
         else:
             chunk = self._compressor.compress(data)
         self._socket.send(chunk + self._compressor.flush(zlib.Z_SYNC_FLUSH))


### PR DESCRIPTION
Tornado 4.5 uses memoryview instead of strings to send data.
Python's deflate compressor cannot process memoryview directly, so it must be explicitly converted to string.

NB. I believe snappy compression has same problem too