### PR TITLE
Add separate method to derive function signature args

### DIFF
--- a/nsq/_compat.py
+++ b/nsq/_compat.py
@@ -66,6 +66,13 @@ except ImportError:
     from cgi import parse_qs
 
 try:
-    from inspect import getargspec as signature
-except ImportError:
     from inspect import signature
+    def func_args(func):
+        items = signature(func).parameters.values()
+        return [param.name for param in items
+                if param.kind == param.POSITIONAL_OR_KEYWORD]
+except ImportError:
+    # inspect.getargspec is deprecated since 3.5
+    from inspect import getargspec
+    def func_args(func):
+        return getargspec(func).args

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -23,7 +23,7 @@ from ._compat import to_bytes
 from ._compat import urlencode
 from ._compat import urlparse
 from ._compat import parse_qs
-from ._compat import signature
+from ._compat import func_args
 from .backoff_timer import BackoffTimer
 from .client import Client
 from . import protocol
@@ -208,7 +208,7 @@ class Reader(Client):
         self.random_rdy_ts = time.time()
 
         # Verify keyword arguments
-        valid_args = signature(async.AsyncConn.__init__)[0]
+        valid_args = func_args(async.AsyncConn.__init__)
         diff = set(kwargs) - set(valid_args)
         assert len(diff) == 0, 'Invalid keyword argument(s): %s' % list(diff)
 

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -7,7 +7,7 @@ import functools
 import random
 
 from ._compat import string_types
-from ._compat import signature
+from ._compat import func_args
 from .client import Client
 from nsq import protocol
 from . import async
@@ -96,7 +96,7 @@ class Writer(Client):
         self.conns = {}
 
         # Verify keyword arguments
-        valid_args = signature(async.AsyncConn.__init__)[0]
+        valid_args = func_args(async.AsyncConn.__init__)
         diff = set(kwargs) - set(valid_args)
         assert len(diff) == 0, 'Invalid keyword argument(s): %s' % list(diff)
 


### PR DESCRIPTION
As promised, a fix for dealing with `inspect.getargspec` being deprecated and `inspect.signature`'s return type not being compatible. This introduces a separate method `func_args` for deriving the method's signature arguments which wraps either `inspect.signature` or `inspect.getargspec` depending on which is available.