### PR TITLE
Update Tornado Compatability Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: python
 python:
   - 2.7
   - 3.5
+  - 3.6
 env:
-  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=3.2.2
-  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=4.4.2
-  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=3.2.2
-  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=4.4.2
+  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=4.1.0
+  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=4.4.3
+  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=4.5.2
+  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=4.1.0
+  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=4.4.3
+  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=4.5.2
 script:
   - ./travis_test.sh
 notifications:

--- a/nsq/deflate_socket.py
+++ b/nsq/deflate_socket.py
@@ -32,13 +32,14 @@ class DeflateSocket(object):
             self._bootstrapped = None
             return data
         chunk = method(size)
-        if chunk:
-            uncompressed = self._decompressor.decompress(chunk)
+        uncompressed = self._decompressor.decompress(chunk) if chunk else None
         if not uncompressed:
             raise socket.error(errno.EWOULDBLOCK)
         return uncompressed
 
     def send(self, data):
+        if isinstance(data, memoryview):
+            data = data.tobytes()
         chunk = self._compressor.compress(data)
         self._socket.send(chunk + self._compressor.flush(zlib.Z_SYNC_FLUSH))
         return len(data)

--- a/nsq/snappy_socket.py
+++ b/nsq/snappy_socket.py
@@ -37,6 +37,8 @@ class SnappySocket(object):
         return uncompressed
 
     def send(self, data):
+        if isinstance(data, memoryview):
+            data = data.tobytes()
         chunk = self._compressor.add_chunk(data, compress=True)
         self._socket.send(chunk)
         return len(data)


### PR DESCRIPTION
This updates pynsq to be tested on tornado 4.5, and adds python 3.6 to the test matrix.

This also drops support for tornado 3.2, and adds test coverage for 4.1.x

Releated to #191 #194