### PR TITLE
Update the `NSQ Protocol` url

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ The official Python client library for `NSQ <https://github.com/nsqio/nsq>`_
 
 It provides high-level :class:`nsq.Reader` and :class:`nsq.Writer` classes for building
 consumers and producers and two low-level modules for both sync and async communication over the
-`NSQ Protocol <https://github.com/nsqio/nsq/blob/master/docs/protocol.md>`_ (if you wanted
+`NSQ Protocol <http://nsq.io/clients/tcp_protocol_spec.html>`_ (if you wanted
 to write your own high-level functionality).
 
 The async module is built on top of the `Tornado IOLoop <http://tornadoweb.org>`_ and as


### PR DESCRIPTION
Hi, I just updated the `NSQ Protocol` url because the old one return 404 status code.