### PR TITLE
pynsq: specify tornado version less than 5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         version
     ),
     packages=['nsq'],
-    install_requires=['tornado'],
+    install_requires=['tornado<5.0'],
     include_package_data=True,
     zip_safe=False,
     tests_require=['pytest', 'mock', 'simplejson',


### PR DESCRIPTION
On March 5th, 2018, version 5.0 of tornado was released http://www.tornadoweb.org/en/stable/releases/v5.0.0.html.

This major version release is currently incompatible with pynsq as some underlying API's have changed.

One such change is where pynsq relies on `tornado.simple_httpclient._default_ca_certs` which no longer exists in v5.0:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/nsq/async.py", line 31, in <module>
    from tornado.simple_httpclient import _default_ca_certs as default_ca_certs
ImportError: cannot import name '_default_ca_certs'
```

There are likely other incompatible changes yet to be determined.  For now, it'd be helpful if `pynsq` specified it's compatible versions.

cc/ @mreiferson 