### PR TITLE
fix high CPU load in DeflateSocket on nsqd disconnection

### DIFF
--- a/nsq/deflate_socket.py
+++ b/nsq/deflate_socket.py
@@ -30,7 +30,9 @@ class DeflateSocket(object):
             self._bootstrapped = None
             return data
         chunk = method(size)
-        uncompressed = self._decompressor.decompress(chunk) if chunk else None
+        if not chunk:
+            return chunk
+        uncompressed = self._decompressor.decompress(chunk)
         if not uncompressed:
             raise socket.error(errno.EWOULDBLOCK)
         return uncompressed

--- a/nsq/snappy_socket.py
+++ b/nsq/snappy_socket.py
@@ -30,7 +30,9 @@ class SnappySocket(object):
             self._bootstrapped = None
             return data
         chunk = method(size)
-        uncompressed = self._decompressor.decompress(chunk) if chunk else None
+        if not chunk:
+            return chunk
+        uncompressed = self._decompressor.decompress(chunk)
         if not uncompressed:
             raise socket.error(errno.EWOULDBLOCK)
         return uncompressed


### PR DESCRIPTION
- fixed handling messages from closed connection in DeflateSocket/SnappySocket recv()
- made DeflateSocket//SnappySocket recv() behaves as standart socket when connection is closed

If connection to nsqd is closed then reading from socket returns empty result and socket should be closed, otherwise it will lead to constant attempt to read from it, and to high cpu load.