### PR TITLE
tests: update Travis-CI test matrix / lib versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,38 @@
 language: python
-python:
-  - 2.7
-  - 3.5
-  - 3.6
-env:
-  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=4.1.0
-  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=4.4.3
-  - NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2 TORNADO_VERSION=4.5.2
-  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=4.1.0
-  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=4.4.3
-  - NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8 TORNADO_VERSION=4.5.2
+sudo: false
+matrix:
+  include:
+  - python: "2.7"
+    env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
+  - python: "2.7"
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
+  - python: "2.7"
+    env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+  - python: "2.7"
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+
+  - python: "3.4"
+    env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
+  - python: "3.4"
+    env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+  - python: "3.4"
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+
+  - python: "3.5"
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
+  - python: "3.5"
+    env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+  - python: "3.5"
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+
+  - python: "3.6"
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
+  - python: "3.6"
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
+    dist: xenial
+    sudo: true
+
 script:
   - ./travis_test.sh
 notifications:
   email: false
-sudo: false

--- a/nsq/async.py
+++ b/nsq/async.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import json
 import time
 import socket
 import logging
@@ -18,11 +19,6 @@ try:
     from .snappy_socket import SnappySocket, SnappyEncoder
 except ImportError:
     SnappyEncoder = SnappySocket = None  # pyflakes.ignore
-
-try:
-    import simplejson as json
-except ImportError:
-    import json  # pyflakes.ignore
 
 import tornado.iostream
 import tornado.ioloop

--- a/nsq/protocol.py
+++ b/nsq/protocol.py
@@ -1,11 +1,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
-import re
 
-try:
-    import simplejson as json
-except ImportError:
-    import json  # pyflakes.ignore
+import re
+import json
 
 from ._compat import bytes_types
 from ._compat import to_bytes

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -6,11 +6,7 @@ import time
 import functools
 import random
 import warnings
-
-try:
-    import simplejson as json
-except ImportError:
-    import json  # pyflakes.ignore
+import json
 
 from tornado.ioloop import PeriodicCallback
 import tornado.httpclient

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ setup(
     install_requires=['tornado<5.0'],
     include_package_data=True,
     zip_safe=False,
-    tests_require=['pytest', 'mock', 'simplejson',
-                   'python-snappy', 'tornado'],
+    tests_require=['pytest<4.0', 'mock', 'python-snappy', 'certifi'],
     cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 6 - Mature',

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -4,11 +4,7 @@ from __future__ import unicode_literals
 import pytest
 import os
 import sys
-
-try:
-    import simplejson as json
-except ImportError:
-    import json  # pyflakes.ignore
+import json
 
 # shunt '..' into sys.path since we are in a 'tests' subdirectory
 base_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -24,7 +24,7 @@ def mock_response_write(c, frame_type, data):
 def mock_response_write_message(c, timestamp, attempts, id, body):
     timestamp_packed = struct_q.pack(timestamp)
     attempts_packed = struct_h.pack(attempts)
-    id = b"%016d" % id
+    id = ("%016d" % id).encode()
     mock_response_write(
         c, protocol.FRAME_TYPE_MESSAGE, timestamp_packed + attempts_packed + id + body)
 
@@ -74,7 +74,7 @@ def test_sync_receive_messages():
 
     for i in range(10):
         c.send(protocol.ready(1))
-        body = b'{"data": {"test_key": %d}}' % i
+        body = ('{"data": {"test_key": %d}}' % i).encode()
         ts = int(time.time() * 1000 * 1000)
         mock_response_write_message(c, ts, 0, i, body)
         resp = c.read_response()
@@ -82,6 +82,6 @@ def test_sync_receive_messages():
         assert unpacked[0] == protocol.FRAME_TYPE_MESSAGE
         msg = protocol.decode_message(unpacked[1])
         assert msg.timestamp == ts
-        assert msg.id == b"%016d" % i
+        assert msg.id == ("%016d" % i).encode()
         assert msg.attempts == 0
         assert msg.body == body

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -26,7 +26,6 @@ echo "travis_fold:start:install.snappy"
 install_snappy
 echo "travis_fold:end:install.snappy"
 echo "travis_fold:start:install.pythondeps"
-pip install simplejson
 pip install certifi
 pip install tornado=="$TORNADO_VERSION"
 PYCURL_SSL_LIBRARY=openssl pip install pycurl

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -11,11 +11,9 @@ install_snappy () {
     # install snappy from source so we can compile with `-fPIC` witout having to sudo install stuff
     git clone https://github.com/google/snappy.git
     cd snappy
-    git checkout 1.1.4
-    sh autogen.sh
-    mkdir -p "$HOME/usr/local"
-    ./configure --prefix="$HOME/usr/local"
-    CFLAGS="-fPIC" make
+    git checkout 1.1.7
+    CFLAGS="-fPIC" CXXFLAGS="-fPIC" \
+        cmake -DCMAKE_INSTALL_PREFIX="$HOME/usr/local"
     make install
     cd ..
 }


### PR DESCRIPTION
I think we can reduce the overall test matrix by not testing everything with everything, but rather being a bit more judicious.

Includes small bumps to to snappy and tornado 4.5.z, removes dependency on simplejson.

Adds experimental python3.7 support, probably a good idea to defer this bit to a follow-up PR ...