### PR TITLE
fix auth_secret identify option on python3

### DIFF
--- a/nsq/conn.py
+++ b/nsq/conn.py
@@ -7,8 +7,7 @@ import time
 import socket
 import logging
 
-from ._compat import string_types
-from ._compat import struct_l
+from ._compat import string_types, to_bytes, struct_l
 from .version import __version__
 
 try:
@@ -161,8 +160,8 @@ class AsyncConn(event.EventedMixin):
         assert isinstance(output_buffer_size, int) and output_buffer_size >= 0
         assert isinstance(output_buffer_timeout, int) and output_buffer_timeout >= 0
         assert isinstance(sample_rate, int) and sample_rate >= 0 and sample_rate < 100
-        assert isinstance(auth_secret, string_types + (None.__class__,))
         assert msg_timeout is None or (isinstance(msg_timeout, (float, int)) and msg_timeout > 0)
+        # auth_secret validated by to_bytes() below
 
         self.state = INIT
         self.host = host
@@ -198,7 +197,7 @@ class AsyncConn(event.EventedMixin):
         self.user_agent = user_agent
 
         self._authentication_required = False  # tracking server auth state
-        self.auth_secret = auth_secret
+        self.auth_secret = to_bytes(auth_secret) if auth_secret else None
 
         self.socket = None
         self.stream = None


### PR DESCRIPTION
The root issue is that on python3 there are conflicting type assertions for auth_secret:

```python
class AsyncConn(...):
    def __init__(...):
         assert isinstance(auth_secret, string_types + (None.__class__,))
...
    def _on_response_continue(...):
        self.send(protocol.auth(self.auth_secret))

# in protocol.py ...

def auth(data):
    return _command(AUTH, data)

def _command(cmd, body, *params):
    assert isinstance(body, bytes_types), 'body must be a bytestring'
```

in #202, @ericb proposed just changing the initial type assertion to allow `bytes_types` instead of `string_types`. I'm fine with that, but I think it might be more "natural" to allow a string for `auth_secret` as well, so I've come up with my own variation using `to_bytes`.

(pushing just the test first to demonstrate failures, then the fix ...)