### PR TITLE
tests: switch from Metafunc.addcall() to mark.parametrize()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=['tornado<5.0'],
     include_package_data=True,
     zip_safe=False,
-    tests_require=['pytest<4.0', 'mock', 'python-snappy', 'certifi'],
+    tests_require=['pytest>=3.3.1', 'mock', 'python-snappy', 'certifi'],
     cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 6 - Mature',

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 import os
 import sys
 
+import pytest
+
 # shunt '..' into sys.path since we are in a 'tests' subdirectory
 base_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 if base_dir not in sys.path:
@@ -13,30 +15,25 @@ from nsq import BackoffTimer
 from nsq import protocol
 
 
-def pytest_generate_tests(metafunc):
-    if metafunc.function == test_topic_names:
-        for name, good in [
-                ('valid_name', True),
-                ('invalid name with space', False),
-                ('invalid_name_due_to_length_this_is_really_really_really_really_long', False),
-                ('test-with_period.', True),
-                ('test#ephemeral', True),
-                ('test:ephemeral', False)]:
-            metafunc.addcall(funcargs=dict(name=name, good=good))
-    if metafunc.function == test_channel_names:
-        for name, good in [
-                ('test', True),
-                ('test-with_period.', True),
-                ('test#ephemeral', True),
-                ('invalid_name_due_to_length_this_is_really_really_really_really_long', False),
-                ('invalid name with space', False)]:
-            metafunc.addcall(funcargs=dict(name=name, good=good))
-
-
+@pytest.mark.parametrize(['name', 'good'], [
+    ('valid_name', True),
+    ('invalid name with space', False),
+    ('invalid_name_due_to_length_this_is_really_really_really_really_long', False),
+    ('test-with_period.', True),
+    ('test#ephemeral', True),
+    ('test:ephemeral', False),
+])
 def test_topic_names(name, good):
     assert protocol.valid_topic_name(name) == good
 
 
+@pytest.mark.parametrize(['name', 'good'], [
+    ('test', True),
+    ('test-with_period.', True),
+    ('test#ephemeral', True),
+    ('invalid_name_due_to_length_this_is_really_really_really_really_long', False),
+    ('invalid name with space', False),
+])
 def test_channel_names(name, good):
     assert protocol.valid_channel_name(name) == good
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,10 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import pytest
 import os
 import sys
 import json
+
+import pytest
 
 # shunt '..' into sys.path since we are in a 'tests' subdirectory
 base_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
@@ -16,57 +17,66 @@ from nsq._compat import struct_l
 from nsq import protocol
 
 
-def pytest_generate_tests(metafunc):
-    identify_dict_ascii = {'a': 1, 'b': 2}
-    identify_dict_unicode = {'c': u'w\xc3\xa5\xe2\x80\xa0'}
-    identify_body_ascii = to_bytes(json.dumps(identify_dict_ascii))
-    identify_body_unicode = to_bytes(json.dumps(identify_dict_unicode))
-
-    msgs = [b'asdf', b'ghjk', b'abcd']
-    mpub_body = struct_l.pack(len(msgs)) + b''.join(struct_l.pack(len(m)) + m for m in msgs)
-    if metafunc.function == test_command:
-        for cmd_method, kwargs, result in [
-                (protocol.identify,
-                    {'data': identify_dict_ascii},
-                    b'IDENTIFY\n' + struct_l.pack(len(identify_body_ascii)) +
-                    to_bytes(identify_body_ascii)),
-                (protocol.identify,
-                    {'data': identify_dict_unicode},
-                    b'IDENTIFY\n' + struct_l.pack(len(identify_body_unicode)) +
-                    to_bytes(identify_body_unicode)),
-                (protocol.subscribe,
-                    {'topic': 'test_topic', 'channel': 'test_channel'},
-                    b'SUB test_topic test_channel\n'),
-                (protocol.finish,
-                    {'id': 'test'},
-                    b'FIN test\n'),
-                (protocol.finish,
-                    {'id': u'\u2020est \xfcn\xee\xe7\xf8\u2202\xe9'},
-                    b'FIN \xe2\x80\xa0est \xc3\xbcn\xc3\xae\xc3\xa7\xc3\xb8\xe2\x88\x82\xc3\xa9\n'),
-                (protocol.requeue,
-                    {'id': 'test'},
-                    b'REQ test 0\n'),
-                (protocol.requeue,
-                    {'id': 'test', 'time_ms': 60},
-                    b'REQ test 60\n'),
-                (protocol.touch,
-                    {'id': 'test'},
-                    b'TOUCH test\n'),
-                (protocol.ready,
-                    {'count': 100},
-                    b'RDY 100\n'),
-                (protocol.nop,
-                    {},
-                    b'NOP\n'),
-                (protocol.pub,
-                    {'topic': 'test', 'data': msgs[0]},
-                    b'PUB test\n' + struct_l.pack(len(msgs[0])) + to_bytes(msgs[0])),
-                (protocol.mpub,
-                    {'topic': 'test', 'data': msgs},
-                    b'MPUB test\n' + struct_l.pack(len(mpub_body)) + to_bytes(mpub_body))]:
-            metafunc.addcall(funcargs=dict(cmd_method=cmd_method, kwargs=kwargs, result=result))
+identify_dict_ascii = {'a': 1, 'b': 2}
+identify_dict_unicode = {'c': u'w\xc3\xa5\xe2\x80\xa0'}
+identify_body_ascii = to_bytes(json.dumps(identify_dict_ascii))
+identify_body_unicode = to_bytes(json.dumps(identify_dict_unicode))
+msgs = [b'asdf', b'ghjk', b'abcd']
+mpub_body = struct_l.pack(len(msgs)) + b''.join(struct_l.pack(len(m)) + m for m in msgs)
 
 
+@pytest.mark.parametrize(['cmd_method', 'kwargs', 'result'], [
+    pytest.param(protocol.identify,
+                 {'data': identify_dict_ascii},
+                 b'IDENTIFY\n' + struct_l.pack(len(identify_body_ascii)) +
+                 to_bytes(identify_body_ascii),
+                 id="identify-ascii"),
+    pytest.param(protocol.identify,
+                 {'data': identify_dict_unicode},
+                 b'IDENTIFY\n' + struct_l.pack(len(identify_body_unicode)) +
+                 to_bytes(identify_body_unicode),
+                 id="identify-unicode"),
+    pytest.param(protocol.subscribe,
+                 {'topic': 'test_topic', 'channel': 'test_channel'},
+                 b'SUB test_topic test_channel\n',
+                 id="subscribe-topic"),
+    pytest.param(protocol.finish,
+                 {'id': 'test'},
+                 b'FIN test\n',
+                 id="finish-ascii"),
+    pytest.param(protocol.finish,
+                 {'id': u'\u2020est \xfcn\xee\xe7\xf8\u2202\xe9'},
+                 b'FIN \xe2\x80\xa0est \xc3\xbcn\xc3\xae\xc3\xa7\xc3\xb8\xe2\x88\x82\xc3\xa9\n',
+                 id="finish-binary"),
+    pytest.param(protocol.requeue,
+                 {'id': 'test'},
+                 b'REQ test 0\n',
+                 id="requeue-0"),
+    pytest.param(protocol.requeue,
+                 {'id': 'test', 'time_ms': 60},
+                 b'REQ test 60\n',
+                 id="requeue-60"),
+    pytest.param(protocol.touch,
+                 {'id': 'test'},
+                 b'TOUCH test\n',
+                 id="touch"),
+    pytest.param(protocol.ready,
+                 {'count': 100},
+                 b'RDY 100\n',
+                 id="ready"),
+    pytest.param(protocol.nop,
+                 {},
+                 b'NOP\n',
+                 id="nop"),
+    pytest.param(protocol.pub,
+                 {'topic': 'test', 'data': msgs[0]},
+                 b'PUB test\n' + struct_l.pack(len(msgs[0])) + to_bytes(msgs[0]),
+                 id="pub"),
+    pytest.param(protocol.mpub,
+                 {'topic': 'test', 'data': msgs},
+                 b'MPUB test\n' + struct_l.pack(len(mpub_body)) + to_bytes(mpub_body),
+                 id="mpub"),
+])
 def test_command(cmd_method, kwargs, result):
     assert cmd_method(**kwargs) == result
 

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -26,6 +26,7 @@ install_snappy
 echo "travis_fold:end:install.snappy"
 echo "travis_fold:start:install.pythondeps"
 pip install flake8
+pip install pytest==3.6.3
 pip install certifi
 pip install tornado=="$TORNADO_VERSION"
 PYCURL_SSL_LIBRARY=openssl pip install pycurl


### PR DESCRIPTION
to avoid deprecation warnings for addcall() from py.test

we need pytest>=3.3.1 for a bugfix for parameters with null bytes
(but travis-ci seems to have pytest-3.3.0 installed ... sometimes??)