### PR TITLE
Remove hardcoded tlsv1 version in ssl.wrap_socket

### DIFF
--- a/nsq/conn.py
+++ b/nsq/conn.py
@@ -300,15 +300,17 @@ class AsyncConn(event.EventedMixin):
         #
         # first remove the event handler for the currently open socket
         # so that when we add the socket to the new SSLIOStream below,
-        # it can re-add the appropriate event handlers.
+        # it can re-add the appropriate event handlers. Default to TLSv1.2
+        # unless ssl_version is set otherwise.
         self.io_loop.remove_handler(self.socket.fileno())
 
         opts = {
             'cert_reqs': ssl.CERT_REQUIRED,
-            'ca_certs': default_ca_certs()
+            'ca_certs': default_ca_certs(),
+            'ssl_version': ssl.PROTOCOL_TLSv1_2
         }
         opts.update(options or {})
-        self.socket = ssl.wrap_socket(self.socket, ssl_version=ssl.PROTOCOL_TLSv1,
+        self.socket = ssl.wrap_socket(self.socket,
                                       do_handshake_on_connect=False, **opts)
 
         self.stream = tornado.iostream.SSLIOStream(self.socket, io_loop=self.io_loop)


### PR DESCRIPTION
Removed the hard coded TLSv1 version in `ssl.wrap_socket`. 

TLS options for a reader can be set with `tls_options`, however the ssl_version is already explicitly set which yields the following error when trying to set a different version:

` TypeError: wrap_socket() got multiple values for keyword argument 'ssl_version'`

This prevents me from using pynsq with `-tls-min-version=tls1.2` set on my nsqds. Removing the hard coded version allows setting this value as/if needed. Running without the hardcoded value, `nsq.Reader` with `tls_v1=True` and omitting `tls_options` correctly uses the min tls version set by nsqd.