### PR TITLE
tests: explicitly install flake8 3.6.0 on travis-ci

### DIFF
--- a/examples/nsq_to_nsq.py
+++ b/examples/nsq_to_nsq.py
@@ -48,7 +48,7 @@ if __name__ == "__main__":
     assert tornado.options.options.destination_nsqd_tcp_address
     assert tornado.options.options.channel
 
-    destination_topic = str(tornado.options.options.destination_topic or
+    destination_topic = str(tornado.options.options.destination_topic or  # noqa: W504
                             tornado.options.options.topic)
     lookupd_http_addresses = map(lambda addr: 'http://' + addr,
                                  tornado.options.options.lookupd_http_address)

--- a/nsq/legacy_reader.py
+++ b/nsq/legacy_reader.py
@@ -17,8 +17,8 @@ class LegacyReader(object):
         from nsq import LegacyReader as Reader
     """
     def __init__(self, *args, **kwargs):
-        warnings.warn('LegacyReader is a deprecated wrapper and will be removed in a future' +
-                      ' release.  Use (multiple) Reader(s) each with their own' +
+        warnings.warn('LegacyReader is a deprecated wrapper and will be removed in a future'
+                      ' release.  Use (multiple) Reader(s) each with their own'
                       ' message handler.', DeprecationWarning)
 
         old_params = {}

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class Reader(Client):
-    """
+    r"""
     Reader provides high-level functionality for building robust NSQ consumers in Python
     on top of the async module.
 
@@ -733,7 +733,7 @@ class Reader(Client):
 
             if self.disabled.__code__ != Reader.disabled.__code__ and \
                semver(data['version']) >= semver('0.3'):
-                warnings.warn('disabled() is deprecated and will be removed in a future release, ' +
+                warnings.warn('disabled() is deprecated and will be removed in a future release, '
                               'use set_max_in_flight(0) instead', DeprecationWarning)
         return super(Reader, self)._on_connection_identify_response(conn, data, **kwargs)
 

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class Writer(Client):
-    """
+    r"""
     A high-level producer class built on top of the `Tornado IOLoop <http://tornadoweb.org>`_
     supporting async publishing (``PUB`` & ``MPUB`` & ``DPUB``) of messages
     to ``nsqd`` over the TCP protocol.

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -28,13 +28,13 @@ mpub_body = struct_l.pack(len(msgs)) + b''.join(struct_l.pack(len(m)) + m for m 
 @pytest.mark.parametrize(['cmd_method', 'kwargs', 'result'], [
     pytest.param(protocol.identify,
                  {'data': identify_dict_ascii},
-                 b'IDENTIFY\n' + struct_l.pack(len(identify_body_ascii)) +
-                 to_bytes(identify_body_ascii),
+                 b'IDENTIFY\n' + struct_l.pack(len(identify_body_ascii))
+                 + to_bytes(identify_body_ascii),  # noqa: W503
                  id="identify-ascii"),
     pytest.param(protocol.identify,
                  {'data': identify_dict_unicode},
-                 b'IDENTIFY\n' + struct_l.pack(len(identify_body_unicode)) +
-                 to_bytes(identify_body_unicode),
+                 b'IDENTIFY\n' + struct_l.pack(len(identify_body_unicode))
+                 + to_bytes(identify_body_unicode),  # noqa: W503
                  id="identify-unicode"),
     pytest.param(protocol.subscribe,
                  {'topic': 'test_topic', 'channel': 'test_channel'},

--- a/travis_test.sh
+++ b/travis_test.sh
@@ -1,11 +1,6 @@
 #!/bin/sh
 set -eu
 
-install_nsq () {
-    wget "http://bitly-downloads.s3.amazonaws.com/nsq/$NSQ_DOWNLOAD.tar.gz"
-    tar zxvf "$NSQ_DOWNLOAD.tar.gz"
-}
-
 install_snappy () {
     # install snappy from source so we can compile with `-fPIC` witout having to sudo install stuff
     git clone https://github.com/google/snappy.git
@@ -18,19 +13,19 @@ install_snappy () {
 }
 
 echo "travis_fold:start:install.nsq"
-install_nsq
+wget "http://bitly-downloads.s3.amazonaws.com/nsq/$NSQ_DOWNLOAD.tar.gz"
+tar zxvf "$NSQ_DOWNLOAD.tar.gz"
 echo "travis_fold:end:install.nsq"
 
 echo "travis_fold:start:install.snappy"
 install_snappy
 echo "travis_fold:end:install.snappy"
+
 echo "travis_fold:start:install.pythondeps"
-pip install flake8
-pip install pytest==3.6.3
-pip install certifi
-pip install tornado=="$TORNADO_VERSION"
+pip install pytest==3.6.3 flake8==3.6.0 certifi
 PYCURL_SSL_LIBRARY=openssl pip install pycurl
 CPPFLAGS="-I$HOME/usr/local/include -L$HOME/usr/local/lib -fPIC" pip install python-snappy
+pip install tornado=="$TORNADO_VERSION"
 echo "travis_fold:end:install.pythondeps"
 
 # Finally, run some tests!


### PR DESCRIPTION
A new version of flake8 was recently released, and new warnings
caused the test-suite to fail. This explicitly installs 3.6.0 so
after the latest warnings are fixed, this won't happen again
unexpectedly.

Also re-arrange travis_test.sh a bit.