### PR TITLE
tests: travis-ci test matrix updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+dist: xenial
 language: python
-sudo: false
 matrix:
   include:
   - python: "2.7"
@@ -11,7 +11,7 @@ matrix:
   - python: "2.7"
     env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
   - python: "2.7"
-    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.1.0-rc1.linux-amd64.go1.10.3
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.1.0.linux-amd64.go1.10.3
 
   - python: "3.4"
     env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
@@ -23,23 +23,17 @@ matrix:
   - python: "3.5"
     env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
   - python: "3.5"
-    env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-1.1.0-rc1.linux-amd64.go1.10.3
+    env: TORNADO_VERSION=4.4.3 NSQ_DOWNLOAD=nsq-1.1.0.linux-amd64.go1.10.3
 
   - python: "3.6"
     env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-0.3.8.linux-amd64.go1.6.2
   - python: "3.6"
     env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
-    dist: xenial
-    sudo: true
 
   - python: "3.7"
     env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.0.0-compat.linux-amd64.go1.8
-    dist: xenial
-    sudo: true
   - python: "3.7"
-    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.1.0-rc1.linux-amd64.go1.10.3
-    dist: xenial
-    sudo: true
+    env: TORNADO_VERSION=4.5.3 NSQ_DOWNLOAD=nsq-1.1.0.linux-amd64.go1.10.3
 
 script:
   - ./travis_test.sh


### PR DESCRIPTION
replace nsq 1.1.0-rc1 with 1.1.0 (final)
use new-ish travis-ci "xenial" base for all

~~try adding pypy to the test matrix~~ pypy has some compatibility issue with the snappy module, we would have to make the tests optionally exclude any dependence on the snappy compression (do I forget this and find out again every time ...)