### PR TITLE
reader: fix setting max_in_flight to 0

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -442,7 +442,7 @@ class Reader(Client):
             value = conn.max_rdy_count
 
         new_rdy = max(self.total_rdy - conn.rdy + value, 0)
-        if new_rdy > self.max_in_flight:
+        if self.max_in_flight != 0 and new_rdy > self.max_in_flight:
             return
 
         if conn.send_rdy(value):


### PR DESCRIPTION
Currently, when we set max_in_flight to 0 to disable consuming by `set_in_max_flight`, it is not working as expected. 

As we need, when we set max_in_flight to 0, the return value of 
> new_rdy = max(self.total_rdy - conn.rdy + value, 0)

in `_send_rdy` is a positive number. Thus the if clause 
> if new_rdy > self.max_in_flight:

will be always true, as currently the value for `self.max_in_flight` is 0.

Thus the `_send_rdy` will shortly return and the new 0 rdy will not be set.