### PR TITLE
reader: in send_rdy(), don't enforce total_rdy <= max_in_flight

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -442,9 +442,6 @@ class Reader(Client):
             value = conn.max_rdy_count
 
         new_rdy = max(self.total_rdy - conn.rdy + value, 0)
-        if new_rdy > self.max_in_flight:
-            return
-
         if conn.send_rdy(value):
             self.total_rdy = new_rdy
 


### PR DESCRIPTION
Naively enforcing that invariant in `_send_rdy()` prevents us from correctly updating each conn's `rdy` after reducing `max_in_flight`.  Additionally, there's no need for this check in `_send_rdy()`, as all callers have logic that's supposed to determine an appropriate rdy value.