### PR TITLE
support tornado-6.x, support coroutine message_handler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,12 @@ jobs:
         tornado_ver:
           - "4.5.3"
           - "5.1.1"
+          - "6.0.4"
+        exclude:
+          - imgtag: "python:2.7-buster"
+            tornado_ver: "6.0.4"
+          - imgtag: "python:3.4-jessie"
+            tornado_ver: "6.0.4"
 
     container: "${{matrix.imgtag}}"
     steps:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-tornado==3.0.2
+tornado==5.1.1

--- a/nsq/__init__.py
+++ b/nsq/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
 import signal
-import tornado.ioloop
 import logging
+
+import tornado.ioloop
 
 from .protocol import (
     Error,
@@ -36,7 +37,7 @@ from .version import __version__  # noqa: F401
 def _handle_term_signal(sig_num, frame):
     logging.getLogger(__name__).info(
         'TERM Signal handler called with signal %r', sig_num)
-    tornado.ioloop.IOLoop.instance().stop()
+    tornado.ioloop.IOLoop.current().stop()
 
 
 def run():
@@ -45,7 +46,7 @@ def run():
     """
     signal.signal(signal.SIGTERM, _handle_term_signal)
     signal.signal(signal.SIGINT, _handle_term_signal)
-    tornado.ioloop.IOLoop.instance().start()
+    tornado.ioloop.IOLoop.current().start()
 
 
 __author__ = "Matt Reiferson <snakes@gmail.com>"

--- a/nsq/conn.py
+++ b/nsq/conn.py
@@ -15,8 +15,8 @@ try:
 except ImportError:
     SnappyEncoder = SnappySocket = None  # pyflakes.ignore
 
-import tornado.iostream
-import tornado.ioloop
+from tornado.iostream import IOStream
+from tornado.ioloop import IOLoop
 
 from nsq import event, protocol
 from .deflate_socket import DeflateSocket, DeflateEncoder
@@ -227,7 +227,7 @@ class AsyncConn(event.EventedMixin):
         self.socket.settimeout(self.timeout)
         self.socket.setblocking(0)
 
-        self.stream = tornado.iostream.IOStream(self.socket)
+        self.stream = IOStream(self.socket)
         self.stream.set_close_callback(self._socket_close)
         self.stream.set_nodelay(True)
 
@@ -236,7 +236,7 @@ class AsyncConn(event.EventedMixin):
         self.on(event.DATA, self._on_data)
 
         fut = self.stream.connect((self.host, self.port))
-        tornado.ioloop.IOLoop.current().add_future(fut, self._connect_callback)
+        IOLoop.current().add_future(fut, self._connect_callback)
 
     def _connect_callback(self, fut):
         fut.result()
@@ -248,7 +248,7 @@ class AsyncConn(event.EventedMixin):
     def _read_bytes(self, size, callback):
         try:
             fut = self.stream.read_bytes(size)
-            tornado.ioloop.IOLoop.current().add_future(fut, callback)
+            IOLoop.current().add_future(fut, callback)
         except IOError:
             self.close()
             self.trigger(
@@ -318,7 +318,7 @@ class AsyncConn(event.EventedMixin):
                     error=protocol.SendError('failed to upgrade to TLS', e),
                 )
 
-        tornado.ioloop.IOLoop.current().add_future(fut, finish_upgrade_tls)
+        IOLoop.current().add_future(fut, finish_upgrade_tls)
 
     def upgrade_to_snappy(self):
         assert SnappySocket, 'snappy requires the python-snappy package'

--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -49,14 +49,20 @@ class Reader(Client):
     It maintains a sufficient RDY count based on the # of producers and your configured
     ``max_in_flight``.
 
-    Handlers should be defined as shown in the examples below. The handler receives a
-    :class:`nsq.Message` object that has instance methods :meth:`nsq.Message.finish`,
-    :meth:`nsq.Message.requeue`, and :meth:`nsq.Message.touch` to respond to ``nsqd``.
+    Handlers should be defined as shown in the examples below. The ``message_handler``
+    callback function receives a :class:`nsq.Message` object that has instance methods
+    :meth:`nsq.Message.finish`, :meth:`nsq.Message.requeue`, and :meth:`nsq.Message.touch`
+    which can be used to respond to ``nsqd``. As an alternative to explicitly calling these
+    response methods, the handler function can simply return ``True`` to finish the message,
+    or ``False`` to requeue it. If the handler function calls :meth:`nsq.Message.enable_async`,
+    then automatic finish/requeue is disabled, allowing the :class:`nsq.Message` to finish or
+    requeue in a later async callback or context. The handler function may also be a coroutine,
+    in which case Message async handling is enabled automatically, but the coroutine
+    can still return a final value of True/False to automatically finish/requeue the message.
 
-    When messages are not responded to explicitly, it is responsible for sending
-    ``FIN`` or ``REQ`` commands based on return value of  ``message_handler``. When
-    re-queueing, it will backoff from processing additional messages for an increasing
-    delay (calculated exponentially based on consecutive failures up to ``max_backoff_duration``).
+    After re-queueing a message, the handler will backoff from processing additional messages
+    for an increasing delay (calculated exponentially based on consecutive failures up to
+    ``max_backoff_duration``).
 
     Synchronous example::
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=['tornado'],
     include_package_data=True,
     zip_safe=False,
-    tests_require=['pytest>=3.3.1', 'mock', 'python-snappy'],
+    tests_require=['pytest>=3.6.3', 'mock', 'python-snappy'],
     cmdclass={'test': PyTest},
     classifiers=[
         'Development Status :: 6 - Mature',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         version
     ),
     packages=['nsq'],
-    install_requires=['tornado<6'],
+    install_requires=['tornado'],
     include_package_data=True,
     zip_safe=False,
     tests_require=['pytest>=3.3.1', 'mock', 'python-snappy'],

--- a/tests/reader_unit_test_helpers.py
+++ b/tests/reader_unit_test_helpers.py
@@ -30,7 +30,7 @@ def get_ioloop():
 
 def get_conn(reader):
     global _conn_port
-    with patch('nsq.conn.tornado.iostream.IOStream', autospec=True) as iostream:
+    with patch('nsq.conn.IOStream', autospec=True) as iostream:
         instance = iostream.return_value
         instance.connect.return_value = Future()
         instance.read_bytes.return_value = Future()

--- a/tests/reader_unit_test_helpers.py
+++ b/tests/reader_unit_test_helpers.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 
+import time
+
 from mock import patch, create_autospec
 from tornado.ioloop import IOLoop
+from tornado.concurrent import Future
 
 import nsq
 from nsq import event
@@ -19,14 +22,18 @@ def get_reader(max_in_flight=5):
 
 
 def get_ioloop():
-    ioloop = create_autospec(IOLoop)
-    ioloop.time.return_value = 0
+    ioloop = create_autospec(IOLoop, instance=True)
+    ioloop.time.side_effect = time.time
+    ioloop.call_later.side_effect = lambda dt, cb: ioloop.add_timeout(time.time() + dt, cb)
     return ioloop
 
 
 def get_conn(reader):
     global _conn_port
-    with patch('nsq.conn.tornado.iostream.IOStream', autospec=True):
+    with patch('nsq.conn.tornado.iostream.IOStream', autospec=True) as iostream:
+        instance = iostream.return_value
+        instance.connect.return_value = Future()
+        instance.read_bytes.return_value = Future()
         conn = reader.connect_to_nsqd('localhost', _conn_port)
     _conn_port += 1
     conn.trigger(event.READY, conn=conn)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -38,7 +38,7 @@ def _get_test_conn():
 #   https://github.com/testing-cabal/mock/issues/323
 #
 @patch('nsq.conn.socket')
-@patch('nsq.conn.tornado.iostream.IOStream', autospec=True)
+@patch('nsq.conn.IOStream', autospec=True)
 def test_connect(mock_iostream, mock_socket):
     instance = mock_iostream.return_value
     fut = Future()


### PR DESCRIPTION
~~needs a couple tests for the new coroutine support~~ (done)
needs pydoc updates

could refactor a bit to use coroutines in one or two more places internally ... tests with mocks make this annoying