### PR TITLE
reader: don't send RDY 1 on a new connection if that would create a max-in-flight violation 

### DIFF
--- a/nsq/reader.py
+++ b/nsq/reader.py
@@ -532,7 +532,8 @@ class Reader(Client):
         #       *initially* starved since redistribute won't apply
         #    2. `max_in_flight < num_conns` ensuring that we never exceed max_in_flight
         #       and rely on the fact that redistribute will handle balancing RDY across conns
-        if not self.backoff_timer.get_interval() or len(self.conns) == 1:
+        if (not self.backoff_timer.get_interval() or len(self.conns) == 1) and \
+           self.total_rdy < self.max_in_flight:
             # only send RDY 1 if we're not in backoff (some other conn
             # should be testing the waters)
             # (but always send it if we're the first)

--- a/tests/test_rdy.py
+++ b/tests/test_rdy.py
@@ -22,3 +22,11 @@ def test_new_conn_throttles_down_existing_conns():
     conn2 = get_conn(r)
     assert conn2.rdy == 1
     assert conn1.rdy == r._connection_max_in_flight()
+
+
+def test_new_conn_respects_max_in_flight():
+    max_in_flight = 1
+    r = get_reader(max_in_flight)
+    get_conn(r)
+    get_conn(r)
+    assert r.total_rdy == max_in_flight


### PR DESCRIPTION
Fixes https://github.com/nsqio/pynsq/issues/252.

Here we add a condition to `Reader._on_connection_ready()` so that we only send RDY 1 on a new connection if doing so won't lead to a max-in-flight violation. Because we earlier in `_on_connection_ready() ` ensure that all connections have RDY less than or equal to the new per-connection max in flight, this condition will only prevent us from sending RDY 1 on a new connection when `max_in_flight` is less than the connection count, in which case we know that RDY redistribution will give RDY to this connection when it's safe.
