### PR TITLE
docs: Fix a few typos

### DIFF
--- a/nsq/backoff_timer.py
+++ b/nsq/backoff_timer.py
@@ -30,7 +30,7 @@ class BackoffTimer(object):
         self.update_interval()
 
     def success(self):
-        """Update the timer to reflect a successfull call"""
+        """Update the timer to reflect a successful call"""
         if self.interval == 0.0:
             return
         self.short_interval -= self.short_unit

--- a/nsq/protocol.py
+++ b/nsq/protocol.py
@@ -16,7 +16,7 @@ FRAME_TYPE_RESPONSE = 0
 FRAME_TYPE_ERROR = 1
 FRAME_TYPE_MESSAGE = 2
 
-# commmands
+# commands
 AUTH = b'AUTH'
 FIN = b'FIN'  # success
 IDENTIFY = b'IDENTIFY'

--- a/nsq/writer.py
+++ b/nsq/writer.py
@@ -46,7 +46,7 @@ class Writer(Client):
         tornado.ioloop.PeriodicCallback(pub_message, 1000).start()
         nsq.run()
 
-    Example publshing a message from a Tornado HTTP request handler::
+    Example publishing a message from a Tornado HTTP request handler::
 
         import functools
         import tornado.httpserver


### PR DESCRIPTION
There are small typos in:
- nsq/backoff_timer.py
- nsq/protocol.py
- nsq/writer.py

Fixes:
- Should read `successful` rather than `successfull`.
- Should read `publishing` rather than `publshing`.
- Should read `commands` rather than `commmands`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md